### PR TITLE
Update package name to QFA where it was forgotten

### DIFF
--- a/src/qfa/__init__.py
+++ b/src/qfa/__init__.py
@@ -1,3 +1,3 @@
 from importlib.metadata import version
 
-__version__ = version("feedback-analysis-backend")
+__version__ = version("qualitative-feedback-analysis")

--- a/uv.lock
+++ b/uv.lock
@@ -299,55 +299,6 @@ wheels = [
 ]
 
 [[package]]
-name = "feedback-analysis-backend"
-version = "0.3.1"
-source = { editable = "." }
-dependencies = [
-    { name = "fastapi" },
-    { name = "gunicorn" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "tenacity" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "azure-identity" },
-    { name = "azure-keyvault-secrets" },
-    { name = "httpx" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-mock" },
-    { name = "ruff" },
-    { name = "ty" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fastapi", specifier = "~=0.135.0" },
-    { name = "gunicorn", specifier = "~=25.3" },
-    { name = "openai", specifier = "~=2.30.0" },
-    { name = "pydantic", specifier = "~=2.0" },
-    { name = "pydantic-settings", specifier = "~=2.0" },
-    { name = "tenacity", specifier = "~=9.1" },
-    { name = "uvicorn", extras = ["standard"], specifier = "~=0.42.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "azure-identity", specifier = "~=1.25" },
-    { name = "azure-keyvault-secrets", specifier = "~=4.10" },
-    { name = "httpx", specifier = "~=0.28" },
-    { name = "pytest", specifier = "~=9.0" },
-    { name = "pytest-asyncio", specifier = "~=1.3.0" },
-    { name = "pytest-mock", specifier = "~=3.15.1" },
-    { name = "ruff", specifier = "~=0.15.0" },
-    { name = "ty", specifier = "==0.0.18" },
-]
-
-[[package]]
 name = "gunicorn"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -809,6 +760,55 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qualitative-feedback-analysis"
+version = "0.4.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "gunicorn" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "tenacity" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "azure-identity" },
+    { name = "azure-keyvault-secrets" },
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = "~=0.135.0" },
+    { name = "gunicorn", specifier = "~=25.3" },
+    { name = "openai", specifier = "~=2.30.0" },
+    { name = "pydantic", specifier = "~=2.0" },
+    { name = "pydantic-settings", specifier = "~=2.0" },
+    { name = "tenacity", specifier = "~=9.1" },
+    { name = "uvicorn", extras = ["standard"], specifier = "~=0.42.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "azure-identity", specifier = "~=1.25" },
+    { name = "azure-keyvault-secrets", specifier = "~=4.10" },
+    { name = "httpx", specifier = "~=0.28" },
+    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest-asyncio", specifier = "~=1.3.0" },
+    { name = "pytest-mock", specifier = "~=3.15.1" },
+    { name = "ruff", specifier = "~=0.15.0" },
+    { name = "ty", specifier = "==0.0.18" },
 ]
 
 [[package]]


### PR DESCRIPTION
After the project was renamed to **qualitative-feedback-analysis** in pyproject.toml, src/qfa/__init__.py still called importlib.metadata.version("**feedback-analysis-backend**"). Importing qfa then raised **PackageNotFoundError** because that distribution name no longer exists (e.g. when starting Uvicorn).

This change updates the lookup to qualitative-feedback-analysis so it matches the installed package metadata.

