### PR TITLE
feat(ci/infra): grant GitHub Actions blob access to Terraform state

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -12,6 +12,7 @@ name: Terraform
 
 on:
   push:
+    branches: [main]
     paths:
       - "infra/**"
   pull_request:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -66,32 +66,38 @@ jobs:
             -backend-config="storage_account_name=${{ vars.AZ_TF_STATE_STORAGE_ACCOUNT }}"
         env:
           ARM_USE_OIDC: true
+          ARM_USE_AZUREAD: true
 
       - name: Select workspace
         run: terraform workspace select ${{ inputs.environment || 'dev' }}
         env:
           ARM_USE_OIDC: true
+          ARM_USE_AZUREAD: true
 
       - name: Terraform plan
         if: ${{ inputs.command != 'apply' }}
         run: terraform plan
         env:
           ARM_USE_OIDC: true
+          ARM_USE_AZUREAD: true
           TF_VAR_subscription_id: ${{ vars.AZ_SUBSCRIPTION_ID }}
           TF_VAR_tenant_id: ${{ vars.AZ_TENANT_ID }}
           TF_VAR_resource_group_name: ${{ vars.AZ_RESOURCE_GROUP }}
           TF_VAR_acr_name: ${{ vars.AZ_ACR_NAME }}
           TF_VAR_acr_resource_group_name: ${{ vars.AZ_ACR_RESOURCE_GROUP }}
           TF_VAR_tf_state_storage_account: ${{ vars.AZ_TF_STATE_STORAGE_ACCOUNT }}
+          TF_VAR_tf_state_resource_group_name: ${{ vars.AZ_TF_STATE_RESOURCE_GROUP }}
 
       - name: Terraform apply
         if: inputs.command == 'apply'
         run: terraform apply -auto-approve
         env:
           ARM_USE_OIDC: true
+          ARM_USE_AZUREAD: true
           TF_VAR_subscription_id: ${{ vars.AZ_SUBSCRIPTION_ID }}
           TF_VAR_tenant_id: ${{ vars.AZ_TENANT_ID }}
           TF_VAR_resource_group_name: ${{ vars.AZ_RESOURCE_GROUP }}
           TF_VAR_acr_name: ${{ vars.AZ_ACR_NAME }}
           TF_VAR_acr_resource_group_name: ${{ vars.AZ_ACR_RESOURCE_GROUP }}
           TF_VAR_tf_state_storage_account: ${{ vars.AZ_TF_STATE_STORAGE_ACCOUNT }}
+          TF_VAR_tf_state_resource_group_name: ${{ vars.AZ_TF_STATE_RESOURCE_GROUP }}

--- a/infra/BOOTSTRAP.md
+++ b/infra/BOOTSTRAP.md
@@ -41,10 +41,11 @@ export TF_VAR_subscription_id=<your-azure-subscription-id>
 #   * tf_state_resource_group_name — where the Terraform state SA lives
 #   * acr_resource_group_name      — where the ACR lives
 #
-# tf_state_resource_group_name is used only by bootstrap.sh and by the
-# `terraform init` command in step 4 (it cannot be a Terraform variable
-# because backend blocks forbid variable interpolation). acr_resource_group_name
-# is read by Terraform via container_registry.tf.
+# Both are read by bootstrap.sh, by the `terraform init` command in step 4
+# (for tf_state_resource_group_name — which cannot be a Terraform backend
+# variable because backend blocks forbid variable interpolation), and by
+# Terraform itself (cicd.tf looks up the state SA to grant CI a blob role;
+# container_registry.tf looks up the ACR).
 #
 # For a single-RG deployment, point both at the same RG. For a multi-RG
 # deployment, point each at its dedicated RG.

--- a/infra/BOOTSTRAP.md
+++ b/infra/BOOTSTRAP.md
@@ -76,7 +76,25 @@ These two resources have to exist before `terraform init` can run, because Terra
 bash bootstrap.sh
 ```
 
-### 4. Initialize Terraform
+### 4. Grant yourself data-plane access to the Terraform state storage account
+
+The backend uses AAD authentication (`use_azuread_auth = true` in `providers.tf`), which talks to blob storage as you rather than fetching the SA's shared key. Azure Contributor/Owner on the resource group does **not** grant data-plane blob operations — you need `Storage Blob Data Contributor` scoped to the SA itself. Without it, `terraform init` in the next step will fail with a 403 `AuthorizationPermissionMismatch`.
+
+```bash
+SA_ID=$(az storage account show \
+  --name "$TF_VAR_tf_state_storage_account" \
+  --resource-group "$TF_VAR_tf_state_resource_group_name" \
+  --query id -o tsv)
+
+az role assignment create \
+  --role "Storage Blob Data Contributor" \
+  --assignee "$(az ad signed-in-user show --query id -o tsv)" \
+  --scope "$SA_ID"
+```
+
+Role assignments take 30–60 seconds to propagate in Azure AD. If the next step still 403s, wait a minute and retry.
+
+### 5. Initialize Terraform
 
 Terraform's `backend` block does not allow variable interpolation, so the resource group and storage account names must be supplied at `terraform init` time via `-backend-config` flags:
 
@@ -95,7 +113,7 @@ az login
 Then re-run the `terraform init` command above.
 If it still fails, make sure your roles are activated in the Azure portal.
 
-### 5. Create workspaces
+### 6. Create workspaces
 
 Terraform uses [workspaces](https://developer.hashicorp.com/terraform/language/state/workspaces)
 to manage `dev`, `staging`, and `prd` environments with separate state files.
@@ -106,7 +124,7 @@ terraform workspace new staging
 terraform workspace new prd
 ```
 
-### 6. Apply each environment and configure its GitHub variables
+### 7. Apply each environment and configure its GitHub variables
 
 This is the per-environment loop. Each environment lives in its own resource group, so `TF_VAR_resource_group_name` must be re-exported before each `terraform apply`. The same export is then used by `gh variable set AZ_RESOURCE_GROUP` to record that environment's RG in its GitHub environment. `terraform output -raw az_client_id` reads from the current workspace's state, so each block's `terraform output` call must follow that block's `terraform apply`.
 
@@ -114,9 +132,12 @@ This is the per-environment loop. Each environment lives in its own resource gro
 REPO="rodekruis/qualitative-feedback-analysis"
 
 # --- repo-scoped variables (shared across all environments) ---
+echo "$TF_VAR_tenant_id"                    | gh variable set AZ_TENANT_ID                --repo "$REPO"
+echo "$TF_VAR_subscription_id"              | gh variable set AZ_SUBSCRIPTION_ID          --repo "$REPO"
 echo "$TF_VAR_tf_state_resource_group_name" | gh variable set AZ_TF_STATE_RESOURCE_GROUP  --repo "$REPO"
 echo "$TF_VAR_tf_state_storage_account"     | gh variable set AZ_TF_STATE_STORAGE_ACCOUNT --repo "$REPO"
 echo "$TF_VAR_acr_resource_group_name"      | gh variable set AZ_ACR_RESOURCE_GROUP       --repo "$REPO"
+echo "$TF_VAR_acr_name"                     | gh variable set AZ_ACR_NAME                 --repo "$REPO"
 
 # === Dev ===
 export TF_VAR_resource_group_name=<your-dev-rg-name>
@@ -125,11 +146,8 @@ terraform apply
 
 gh api repos/$REPO/environments/dev -X PUT
 gh variable set AZ_CLIENT_ID       --env dev --repo $REPO --body "$(terraform output -raw az_client_id)"
-gh variable set AZ_TENANT_ID       --env dev --repo $REPO --body "$TF_VAR_tenant_id"
-gh variable set AZ_SUBSCRIPTION_ID --env dev --repo $REPO --body "$TF_VAR_subscription_id"
 gh variable set AZ_RESOURCE_GROUP  --env dev --repo $REPO --body "$TF_VAR_resource_group_name"
 gh variable set AZ_APP_NAME        --env dev --repo $REPO --body "qfa-dev-backend"
-gh variable set AZ_ACR_NAME        --env dev --repo $REPO --body "$TF_VAR_acr_name"
 
 # === Staging ===
 export TF_VAR_resource_group_name=<your-staging-rg-name>
@@ -138,11 +156,8 @@ terraform apply
 
 gh api repos/$REPO/environments/staging -X PUT
 gh variable set AZ_CLIENT_ID       --env staging --repo $REPO --body "$(terraform output -raw az_client_id)"
-gh variable set AZ_TENANT_ID       --env staging --repo $REPO --body "$TF_VAR_tenant_id"
-gh variable set AZ_SUBSCRIPTION_ID --env staging --repo $REPO --body "$TF_VAR_subscription_id"
 gh variable set AZ_RESOURCE_GROUP  --env staging --repo $REPO --body "$TF_VAR_resource_group_name"
 gh variable set AZ_APP_NAME        --env staging --repo $REPO --body "qfa-staging-backend"
-gh variable set AZ_ACR_NAME        --env staging --repo $REPO --body "$TF_VAR_acr_name"
 
 # === Production ===
 export TF_VAR_resource_group_name=<your-prd-rg-name>
@@ -151,16 +166,13 @@ terraform apply
 
 gh api repos/$REPO/environments/prd -X PUT
 gh variable set AZ_CLIENT_ID       --env prd --repo $REPO --body "$(terraform output -raw az_client_id)"
-gh variable set AZ_TENANT_ID       --env prd --repo $REPO --body "$TF_VAR_tenant_id"
-gh variable set AZ_SUBSCRIPTION_ID --env prd --repo $REPO --body "$TF_VAR_subscription_id"
 gh variable set AZ_RESOURCE_GROUP  --env prd --repo $REPO --body "$TF_VAR_resource_group_name"
 gh variable set AZ_APP_NAME        --env prd --repo $REPO --body "qfa-prd-backend"
-gh variable set AZ_ACR_NAME        --env prd --repo $REPO --body "$TF_VAR_acr_name"
 ```
 
 The `terraform.yaml` workflow can now run autonomously in CI.
 
-### 7. Seed Key Vault secrets
+### 8. Seed Key Vault secrets
 
 The App Service reads three secrets from Key Vault at runtime via [Key Vault references](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references) (configured in `app_service.tf`). Terraform creates the vault and grants the App Service read access (`Key Vault Secrets User`), but does **not** manage secret values — those are set out-of-band to keep them out of Terraform state.
 
@@ -199,4 +211,4 @@ After the bootstrap, infrastructure changes follow the normal workflow:
 - Open a PR touching `infra/` → CI runs `terraform plan` automatically
 - Merge to `main` → trigger `terraform apply` manually from the Actions tab
 
-If the managed identity is ever recreated (e.g. after `terraform destroy`), re-run the affected environment's block from step 6 to update `AZ_CLIENT_ID`.
+If the managed identity is ever recreated (e.g. after `terraform destroy`), re-run the affected environment's block from step 7 to update `AZ_CLIENT_ID`.

--- a/infra/app_service.tf
+++ b/infra/app_service.tf
@@ -89,7 +89,7 @@ resource "azurerm_role_assignment" "app_keyvault_secrets" {
 
 # Grant the App Service pull access to ACR
 resource "azurerm_role_assignment" "app_acr_repository_reader" {
-  scope                = data.azurerm_container_registry.acr.id
+  scope                = local.acr_id
   role_definition_name = "Container Registry Repository Reader"
   principal_id         = azurerm_linux_web_app.backend.identity[0].principal_id
 }

--- a/infra/cicd.tf
+++ b/infra/cicd.tf
@@ -48,6 +48,21 @@ resource "azurerm_role_assignment" "github_contributor" {
   principal_id         = azurerm_user_assigned_identity.github.principal_id
 }
 
+# GitHub Actions identity needs data-plane access to the Terraform state
+# storage account so `terraform init`/`plan`/`apply` in CI can read and write
+# the state blob. Scoped to the SA (not the state RG) so the assignment cannot
+# accidentally widen if other resources are later added to that RG.
+data "azurerm_storage_account" "tfstate" {
+  name                = var.tf_state_storage_account
+  resource_group_name = var.tf_state_resource_group_name
+}
+
+resource "azurerm_role_assignment" "github_tfstate_blob_contributor" {
+  scope                = data.azurerm_storage_account.tfstate.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.github.principal_id
+}
+
 resource "azurerm_federated_identity_credential" "github_environment" {
   name                      = "gh-qualitative-feedback-analysis-${local.env}"
   user_assigned_identity_id = azurerm_user_assigned_identity.github.id

--- a/infra/cicd.tf
+++ b/infra/cicd.tf
@@ -21,7 +21,7 @@ resource "azurerm_user_assigned_identity" "github" {
 
 # Grant GitHub Actions write access to ACR (for CI/CD image builds)
 resource "azurerm_role_assignment" "github_acr_repository_writer" {
-  scope                = data.azurerm_container_registry.acr.id
+  scope                = local.acr_id
   role_definition_name = "Container Registry Repository Writer"
   principal_id         = azurerm_user_assigned_identity.github.principal_id
 }
@@ -52,13 +52,8 @@ resource "azurerm_role_assignment" "github_contributor" {
 # storage account so `terraform init`/`plan`/`apply` in CI can read and write
 # the state blob. Scoped to the SA (not the state RG) so the assignment cannot
 # accidentally widen if other resources are later added to that RG.
-data "azurerm_storage_account" "tfstate" {
-  name                = var.tf_state_storage_account
-  resource_group_name = var.tf_state_resource_group_name
-}
-
 resource "azurerm_role_assignment" "github_tfstate_blob_contributor" {
-  scope                = data.azurerm_storage_account.tfstate.id
+  scope                = local.tfstate_sa_id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_user_assigned_identity.github.principal_id
 }

--- a/infra/cicd.tf
+++ b/infra/cicd.tf
@@ -58,6 +58,29 @@ resource "azurerm_role_assignment" "github_tfstate_blob_contributor" {
   principal_id         = azurerm_user_assigned_identity.github.principal_id
 }
 
+# CI identity needs to read role assignments at shared-infra scopes so that
+# `terraform plan` can refresh the azurerm_role_assignment resources defined
+# here and in app_service.tf. The narrower data-plane roles already granted
+# (Container Registry Repository Writer, Storage Blob Data Contributor) do
+# not include Microsoft.Authorization/roleAssignments/read — only control-
+# plane roles do. `Reader` scoped per-resource is the least-privilege fit:
+# it grants `*/read` on exactly these two resources, nothing else.
+#
+# Write-side (apply creating or modifying role assignments at these scopes)
+# still requires operator credentials in a local apply. Reader covers the
+# steady-state CI plan/apply cycle.
+resource "azurerm_role_assignment" "github_acr_reader" {
+  scope                = local.acr_id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.github.principal_id
+}
+
+resource "azurerm_role_assignment" "github_tfstate_reader" {
+  scope                = local.tfstate_sa_id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.github.principal_id
+}
+
 resource "azurerm_federated_identity_credential" "github_environment" {
   name                      = "gh-qualitative-feedback-analysis-${local.env}"
   user_assigned_identity_id = azurerm_user_assigned_identity.github.id

--- a/infra/container_registry.tf
+++ b/infra/container_registry.tf
@@ -1,8 +1,14 @@
 # =============================================================================
-# Container Registry (read-only — managed outside Terraform)
+# Container Registry — referenced by constructed resource ID
 # =============================================================================
-
-data "azurerm_container_registry" "acr" {
-  name                = var.acr_name
-  resource_group_name = var.acr_resource_group_name
-}
+# The ACR is managed outside Terraform (see bootstrap.sh) and lives in a
+# shared RG. We do not use a `data "azurerm_container_registry"` block because
+# that would require the CI identity to hold control-plane read on the ACR,
+# widening its role footprint beyond the data-plane `Container Registry
+# Repository Writer` it actually needs. Instead, the ACR's resource ID is
+# constructed deterministically in locals.tf (`local.acr_id`) from
+# var.subscription_id, var.acr_resource_group_name, and var.acr_name.
+#
+# Role assignments referencing ACR:
+#   - azurerm_role_assignment.github_acr_repository_writer (cicd.tf)
+#   - azurerm_role_assignment.app_acr_repository_reader    (app_service.tf)

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -6,4 +6,11 @@ locals {
   keyvault_name         = "qfa-${local.env}-keyvault"
   managed_identity_name = "qfa-${local.env}-github"
   github_environment    = local.env
+
+  # Resource IDs for shared infra. Constructed deterministically from variables
+  # rather than looked up via `data` sources so the CI identity does not need
+  # control-plane read on these resources — it only needs the roles it is
+  # explicitly granted (ACR push, tfstate blob write, etc.).
+  tfstate_sa_id = "/subscriptions/${var.subscription_id}/resourceGroups/${var.tf_state_resource_group_name}/providers/Microsoft.Storage/storageAccounts/${var.tf_state_storage_account}"
+  acr_id        = "/subscriptions/${var.subscription_id}/resourceGroups/${var.acr_resource_group_name}/providers/Microsoft.ContainerRegistry/registries/${var.acr_name}"
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -5,7 +5,7 @@ output "app_url" {
 
 output "acr_login_server" {
   description = "ACR login server URL"
-  value       = data.azurerm_container_registry.acr.login_server
+  value       = "${var.acr_name}.azurecr.io"
 }
 
 output "keyvault_uri" {

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -15,8 +15,9 @@ terraform {
     # ("Variables may not be used here"), so they cannot be read from
     # var.resource_group_name / var.tf_state_storage_account directly.
     # See infra/BOOTSTRAP.md for the init invocation.
-    container_name = "tfstate"
-    key            = "terraform.tfstate"
+    container_name   = "tfstate"
+    key              = "terraform.tfstate"
+    use_azuread_auth = true
   }
 }
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -23,6 +23,11 @@ variable "tf_state_storage_account" {
   type        = string
 }
 
+variable "tf_state_resource_group_name" {
+  description = "RG containing the Terraform state storage account. Separate from resource_group_name so state can live outside any environment RG."
+  type        = string
+}
+
 variable "acr_name" {
   description = "Globally unique name of the shared Azure Container Registry. Must be set explicitly per deployment to avoid name collisions across Azure tenants. ACR names are alphanumeric only (no dashes)."
   type        = string

--- a/src/qfa/__init__.py
+++ b/src/qfa/__init__.py
@@ -1,3 +1,3 @@
 from importlib.metadata import version
 
-__version__ = version("feedback-analysis-backend")
+__version__ = version("qualitative-feedback-analysis")

--- a/uv.lock
+++ b/uv.lock
@@ -299,55 +299,6 @@ wheels = [
 ]
 
 [[package]]
-name = "feedback-analysis-backend"
-version = "0.3.1"
-source = { editable = "." }
-dependencies = [
-    { name = "fastapi" },
-    { name = "gunicorn" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "tenacity" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "azure-identity" },
-    { name = "azure-keyvault-secrets" },
-    { name = "httpx" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-mock" },
-    { name = "ruff" },
-    { name = "ty" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fastapi", specifier = "~=0.135.0" },
-    { name = "gunicorn", specifier = "~=25.3" },
-    { name = "openai", specifier = "~=2.30.0" },
-    { name = "pydantic", specifier = "~=2.0" },
-    { name = "pydantic-settings", specifier = "~=2.0" },
-    { name = "tenacity", specifier = "~=9.1" },
-    { name = "uvicorn", extras = ["standard"], specifier = "~=0.42.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "azure-identity", specifier = "~=1.25" },
-    { name = "azure-keyvault-secrets", specifier = "~=4.10" },
-    { name = "httpx", specifier = "~=0.28" },
-    { name = "pytest", specifier = "~=9.0" },
-    { name = "pytest-asyncio", specifier = "~=1.3.0" },
-    { name = "pytest-mock", specifier = "~=3.15.1" },
-    { name = "ruff", specifier = "~=0.15.0" },
-    { name = "ty", specifier = "==0.0.18" },
-]
-
-[[package]]
 name = "gunicorn"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -809,6 +760,55 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qualitative-feedback-analysis"
+version = "0.4.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "gunicorn" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "tenacity" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "azure-identity" },
+    { name = "azure-keyvault-secrets" },
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = "~=0.135.0" },
+    { name = "gunicorn", specifier = "~=25.3" },
+    { name = "openai", specifier = "~=2.30.0" },
+    { name = "pydantic", specifier = "~=2.0" },
+    { name = "pydantic-settings", specifier = "~=2.0" },
+    { name = "tenacity", specifier = "~=9.1" },
+    { name = "uvicorn", extras = ["standard"], specifier = "~=0.42.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "azure-identity", specifier = "~=1.25" },
+    { name = "azure-keyvault-secrets", specifier = "~=4.10" },
+    { name = "httpx", specifier = "~=0.28" },
+    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest-asyncio", specifier = "~=1.3.0" },
+    { name = "pytest-mock", specifier = "~=3.15.1" },
+    { name = "ruff", specifier = "~=0.15.0" },
+    { name = "ty", specifier = "==0.0.18" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add `azurerm_role_assignment` for GitHub's user-assigned identity to provide `Storage Blob Data Contributor` access to the state SA, ensuring CI can manage the state without broader RG permissions.
- Update workflows to pass the `tf_state_resource_group_name` variable to Terraform.
- Enable Azure AD authentication for Terraform backend and workflows for more secure state management.
- Enhance `BOOTSTRAP.md` documentation to clarify the storage and resource group configurations.