### PR TITLE
feat: auto-update semantic version in lock file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
 Homepage = "https://github.com/rodekruis/qualitative-feedback-analysis"
 Repository = "https://github.com/rodekruis/qualitative-feedback-analysis"
 
+[project.optional-dependencies]
+build = ["uv ~= 0.11.7"] # Included for the build command in semantic-release
+
 [tool.hatch.build]
 packages = ["src/qfa"]
 
@@ -90,6 +93,11 @@ invalid-method-override = "ignore"
 version_toml = ["pyproject.toml:project.version"]
 commit_parser = "conventional"
 allow_zero_version = true
+build_command = """
+    uv lock --upgrade-package "$PACKAGE_NAME"
+    git add uv.lock
+    uv build
+"""
 
 [tool.semantic_release.branches.main]
 match = "(master|main)"


### PR DESCRIPTION
## Problem

The current `semantic-release` implementation only increases the releases in the pyproject.toml, but does not  update the version in the `uv.lock` file.

## Solution

This functionality from [the documentation of `python-semantic-release`](https://python-semantic-release.readthedocs.io/en/latest/configuration/configuration-guides/uv_integration.html#updating-the-uv-lock) adds this functionality.