### PR TITLE
chore: upgrade and pin GitHub Actions to node 24 compatible versions

### DIFF
--- a/.github/workflows/_deploy-release.yaml
+++ b/.github/workflows/_deploy-release.yaml
@@ -60,7 +60,7 @@ jobs:
           echo "Deploying ${{ inputs.release_tag }} ($DIGEST) to ${{ inputs.environment }}"
 
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ vars.AZ_CLIENT_ID }}
           tenant-id: ${{ vars.AZ_TENANT_ID }}

--- a/.github/workflows/build-from-commit.yaml
+++ b/.github/workflows/build-from-commit.yaml
@@ -37,12 +37,12 @@ jobs:
       digest: ${{ steps.push.outputs.digest }}
       tag: ${{ steps.push.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
 
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ vars.AZ_CLIENT_ID }}
           tenant-id: ${{ vars.AZ_TENANT_ID }}
@@ -79,7 +79,7 @@ jobs:
     environment: dev
     steps:
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ vars.AZ_CLIENT_ID }}
           tenant-id: ${{ vars.AZ_TENANT_ID }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,13 +19,13 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install dependencies
         run: uv sync
       - name: ruff format
@@ -39,7 +39,7 @@ jobs:
     # Intentionally NOT pushing the image. That's a separate job ("release")..
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build Docker image (no push)
         run: docker build .
 
@@ -52,13 +52,13 @@ jobs:
           - "3.12"
           - "3.13"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install dependencies
         run: uv sync
       - name: Run pytest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,14 +67,14 @@ jobs:
       tag: ${{ steps.semrel.outputs.tag }}
       is_prerelease: ${{ steps.semrel.outputs.is_prerelease }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
 
       - name: Semantic Release (version only)
         id: semrel
-        uses: python-semantic-release/python-semantic-release@v10
+        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force: ${{ github.event.inputs.force }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Login to Azure
         if: steps.semrel.outputs.released == 'true'
-        uses: azure/login@v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ vars.AZ_CLIENT_ID }}
           tenant-id: ${{ vars.AZ_TENANT_ID }}

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -49,16 +49,16 @@ jobs:
         working-directory: infra
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ vars.AZ_CLIENT_ID }}
           tenant-id: ${{ vars.AZ_TENANT_ID }}
           subscription-id: ${{ vars.AZ_SUBSCRIPTION_ID }}
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
 
       - name: Terraform init
         run: |


### PR DESCRIPTION
## Summary

- Upgrades all third-party GitHub Actions to their latest releases, which use the node 24 runtime (resolves node 20 deprecation warnings)
- Pins every action to its exact commit SHA to prevent supply chain attacks

## Action upgrades

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `v4` | `v6.0.2` (`de0fac2e`) |
| `actions/setup-python` | `v5` | `v6.2.0` (`a309ff8b`) |
| `astral-sh/setup-uv` | `v5` | `v8.1.0` (`08807647`) |
| `azure/login` | `v2` | `v3.0.0` (`532459ea`) |
| `hashicorp/setup-terraform` | `v3` | `v4.0.0` (`5e8dbf3c`) |
| `python-semantic-release/python-semantic-release` | `v10` | `v10.5.3` (`350c48fc`) |

Closes #34
Closes #35