### PR TITLE
fix(release): add GitHub App token creation to bypass main branch rules

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,8 +67,20 @@ jobs:
       tag: ${{ steps.semrel.outputs.tag }}
       is_prerelease: ${{ steps.semrel.outputs.is_prerelease }}
     steps:
+      # Requires org/repo admin setup: create RELEASE_APP_CLIENT_ID,
+      # create RELEASE_APP_PRIVATE_KEY, install the GitHub App on this repo,
+      # and allow the app to bypass the main branch ruleset.
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.ref_name }}
           fetch-depth: 0
 
@@ -76,7 +88,7 @@ jobs:
         id: semrel
         uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           force: ${{ github.event.inputs.force }}
           prerelease: ${{ github.event.inputs.prerelease }}
           prerelease_token: ${{ github.event.inputs.prerelease_token }}
@@ -151,7 +163,7 @@ jobs:
       - name: Create draft GitHub Release
         if: steps.semrel.outputs.released == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PRERELEASE_FLAG=""
           if [ "${{ steps.semrel.outputs.is_prerelease }}" = "true" ]; then


### PR DESCRIPTION
## Why this change

Our release workflow currently fails at the Semantic Release step because it needs to commit a version bump and push tags back to `main`, while the default workflow token cannot bypass the repository ruleset.

This PR updates the workflow to use a GitHub App installation token instead of `GITHUB_TOKEN` for the release write operations.

The workflow now:

- Creates a GitHub App installation token at runtime
- Uses that token for repository checkout
- Uses that token for Python Semantic Release
- Uses that token for creating the draft GitHub release

## Admin actions required

An organization or repository admin must complete the GitHub-side setup before this workflow will work:

1. Create a private GitHub App for release automation.
2. Grant the app repository permission `Contents: Read and write`.
3. Install the app on this repository.
4. Add the app as a bypass actor on the ruleset that blocks direct pushes to `main`.
5. If tag rulesets are also enforced for release tags, add the app as a bypass actor there as well.
6. Create a GitHub Actions variable named `RELEASE_APP_CLIENT_ID` with the app client ID.
7. Create a GitHub Actions secret named `RELEASE_APP_PRIVATE_KEY` with the app private key PEM content.

## Notes

- This change only works if the ruleset explicitly allows the GitHub App to bypass it.
- If the organization policy is that no automation may push directly to `main`, even via a GitHub App bypass, then this workflow model is still incompatible and the release process will need to change to a PR-based or tag-only approach.