### PR TITLE
fix(terraform): add -input=false flag to Terraform plan command

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Terraform plan
         if: ${{ inputs.command != 'apply' }}
-        run: terraform plan
+        run: terraform plan -input=false
         env:
           ARM_USE_OIDC: true
           ARM_USE_AZUREAD: true


### PR DESCRIPTION
In case the terraform input variables change, the `terraform.yml` workflow would hang waiting for user-input:

<img width="550" height="160" alt="image" src="https://github.com/user-attachments/assets/94add495-c30e-44d1-8bd1-9293d5382150" />

This tells the workflow that we don't have any input to type in