### PR TITLE
feat(EspoCRM): add scripts for summarize features

### DIFF
--- a/scripts/espo_crm/set_summarize_aggregate_payload
+++ b/scripts/espo_crm/set_summarize_aggregate_payload
@@ -1,0 +1,97 @@
+// Script for settings summarize aggregate feature payload in EspoCRM
+
+// Find the related feedback records
+$$backendIDs = record\findRelatedMany('CInsight', id, 'feedbackDatas', 9999,'createdAt', 'desc');
+
+// TODO: Add fields to UI
+$additionalPrompt = "";
+$outputLanguage = "English";
+
+// Initialize loop variables
+$i = 0;
+$itemsString = '';
+$count = array\length($$backendIDs);
+
+// Loop through real records
+while($i < $count) {
+  $$backendID = array\at($$backendIDs, $i);
+
+  // Fetch real attributes
+  $feedbackDescription = record\attribute('CFeedbackData', $$backendID, 'feedbackDescription');
+  $feedbackID = record\attribute('CFeedbackData', $$backendID, 'feedbackFormID');
+  $codingLevel1 = "Placeholder";    // TODO
+  $codingLevel2 = "Placeholder";    // TODO
+  $codingLevel3 = "Placeholder";    // TODO
+  $createdAt = record\attribute('CFeedbackData', $$backendID, 'createdAt');
+
+  // Clean the feedback description string
+  $feedbackDescription = string\replace($feedbackDescription, "\n", " ");
+  $feedbackDescription = string\replace($feedbackDescription, "\r", "");
+  
+  // Fill metadata JSON string
+  $metadata = string\concatenate(
+    '{',
+      '"coding_level_1": "', $codingLevel1, '", ',
+      '"coding_level_2": "', $codingLevel2, '", ',
+      '"coding_level_3": "', $codingLevel3, '", ',
+      '"created": "', $createdAt, '", ',
+      '"feedback_item_id": "', $feedbackID, '"',
+    '}'
+  );
+  
+  // Fill item-level JSON string
+  $item = string\concatenate(
+      '{"content": "', $feedbackDescription, '", "id": "', $feedbackID, '", ', 
+      '"metadata": ', $metadata, '}'
+  );
+
+  // Add a comma between items, except first one
+  if ($i == 0) {
+      $itemsString = $item;
+  } else {
+      $itemsString = string\concatenate($itemsString, ',', $item);
+  }
+
+  $i = $i + 1;
+}
+
+// Build the payload JSON string
+$$payload = string\concatenate(
+    '{',
+    '"feedback_items": [', $itemsString, '],',
+    '"output_language": "'$outputLanguage'",',
+    '"prompt": "', $additionalPrompt, '"',
+    '}'
+);
+
+
+
+// // Test payload: uncomment to succesfully run rest of workflow
+// $$payload = '{
+//     "feedback_items": [
+//         {
+//             "content": "I ate some delicious roti at a suraam place, this is a test message",
+//             "id": "doc-001",
+//             "metadata": {
+//                 "coding_level_1": "Water",
+//                 "coding_level_2": "Distribution",
+//                 "coding_level_3": "Waiting times",
+//                 "created": "2024-06-01T12:00:00Z",
+//                 "feedback_item_id": "fi-001"
+//             }
+//         },
+//         {
+//             "content": "During the mobile clinic in the settlement after the floods, the medical",
+//             "id": "doc-002",
+//             "metadata": {
+//                 "coding_level_1": "Health",
+//                 "coding_level_2": "Staff",
+//                 "coding_level_3": "Supplies",
+//                 "created": "2024-06-02T09:30:00Z",
+//                 "feedback_item_id": "fi-002"
+//             }
+//         }
+//     ],
+//     "output_language": "English",
+//     "prompt": "Focus on operational issues and beneficiary experience."
+// }';

--- a/scripts/espo_crm/set_summarize_per_item_payload
+++ b/scripts/espo_crm/set_summarize_per_item_payload
@@ -1,0 +1,97 @@
+// Script for settings summarize per item feature payload in EspoCRM
+
+// Find the related feedback records
+$$backendIDs = record\findRelatedMany('CInsight', id, 'feedbackDatas', 9999,'createdAt', 'desc');
+
+// TODO: Add fields to UI
+$additionalPrompt = "";
+$outputLanguage = "English";
+
+// Initialize loop variables
+$i = 0;
+$itemsString = '';
+$count = array\length($$backendIDs);
+
+// Loop through real records
+while($i < $count) {
+  $$backendID = array\at($$backendIDs, $i);
+
+  // Fetch real attributes
+  $feedbackDescription = record\attribute('CFeedbackData', $$backendID, 'feedbackDescription');
+  $feedbackID = record\attribute('CFeedbackData', $$backendID, 'feedbackFormID');
+  $codingLevel1 = "Placeholder";    // TODO
+  $codingLevel2 = "Placeholder";    // TODO
+  $codingLevel3 = "Placeholder";    // TODO
+  $createdAt = record\attribute('CFeedbackData', $$backendID, 'createdAt');
+
+  // Clean the feedback description string
+  $feedbackDescription = string\replace($feedbackDescription, "\n", " ");
+  $feedbackDescription = string\replace($feedbackDescription, "\r", "");
+  
+  // Fill metadata JSON string
+  $metadata = string\concatenate(
+    '{',
+      '"coding_level_1": "', $codingLevel1, '", ',
+      '"coding_level_2": "', $codingLevel2, '", ',
+      '"coding_level_3": "', $codingLevel3, '", ',
+      '"created": "', $createdAt, '", ',
+      '"feedback_item_id": "', $feedbackID, '"',
+    '}'
+  );
+  
+  // Fill item-level JSON string
+  $item = string\concatenate(
+      '{"content": "', $feedbackDescription, '", "id": "', $feedbackID, '", ', 
+      '"metadata": ', $metadata, '}'
+  );
+
+  // Add a comma between items, except first one
+  if ($i == 0) {
+      $itemsString = $item;
+  } else {
+      $itemsString = string\concatenate($itemsString, ',', $item);
+  }
+
+  $i = $i + 1;
+}
+
+// Build the payload JSON string
+$$payload = string\concatenate(
+    '{',
+    '"feedback_items": [', $itemsString, '],',
+    '"output_language": "'$outputLanguage'",',
+    '"prompt": "', $additionalPrompt, '"',
+    '}'
+);
+
+
+
+// // Test payload: uncomment to succesfully run rest of workflow
+// $$payload = '{
+//     "feedback_items": [
+//         {
+//             "content": "I ate some delicious roti at a suraam place, this is a test message",
+//             "id": "doc-001",
+//             "metadata": {
+//                 "coding_level_1": "Water",
+//                 "coding_level_2": "Distribution",
+//                 "coding_level_3": "Waiting times",
+//                 "created": "2024-06-01T12:00:00Z",
+//                 "feedback_item_id": "fi-001"
+//             }
+//         },
+//         {
+//             "content": "During the mobile clinic in the settlement after the floods, the medical",
+//             "id": "doc-002",
+//             "metadata": {
+//                 "coding_level_1": "Health",
+//                 "coding_level_2": "Staff",
+//                 "coding_level_3": "Supplies",
+//                 "created": "2024-06-02T09:30:00Z",
+//                 "feedback_item_id": "fi-002"
+//             }
+//         }
+//     ],
+//     "output_language": "English",
+//     "prompt": "Focus on operational issues and beneficiary experience."
+// }';

--- a/scripts/espo_crm/translate_summarize_aggregate_reponse_to_ouput
+++ b/scripts/espo_crm/translate_summarize_aggregate_reponse_to_ouput
@@ -1,0 +1,44 @@
+// Script for translating reponse to output string for summarize aggregate feature in EspoCRM
+
+$response = $_lastHttpResponseBody;
+
+// Extract aggregate summary fields                                                 
+$title = json\retrieve($response, 'summary.title');                                 
+$summary = json\retrieve($response, 'summary.summary');                             
+$score = json\retrieve($response, 'summary.quality_score');
+
+// Build IDs string from the ids array       
+$idsList = json\retrieve($response, 'summary.ids');
+$idsCount = array\length($idsList);             
+$idsString = '';
+$j = 0;
+while ($j < $idsCount) {                                                       
+  $id = array\at($idsList, $j);
+  if ($j > 0) { $idsString = string\concatenate($idsString, ', '); }
+  $idsString = string\concatenate($idsString, $id);                  
+  $j = $j + 1;
+}  
+  
+// Determine the Visual Dot Rating                                                     
+$dots = '○○○○○';
+if ($score >= 0.9) { $dots = '●●●●●'; }                                                 
+else if ($score >= 0.7) { $dots = '●●●●○'; }
+else if ($score >= 0.5) { $dots = '●●●○○'; }                                            
+else if ($score >= 0.3) { $dots = '●●○○○'; }
+else if ($score >= 0.1) { $dots = '●○○○○'; }                                                                                                            
+// Format the Percentage
+$numericScore = $score + 0; // Type casting trick                                       
+$percentageValue = $numericScore * 100;
+$percent = string\concatenate(number\format($percentageValue, 0, '.', ''), '%');
+
+// Build the aggregate block
+$finalString = string\concatenate( 
+    "IDs:            ", $idsString, "\n",
+    "QUALITY:        ", $dots, " ", $percent, "\n",
+    "TITLE:          ", $title, "\n",
+    "SUMMARY:        \n", $summary, "\n",                                               
+    "------------------------------------------------------------\n\n"
+);                                                                                      
+                
+// Output the result to your field
+modelResponse = $finalString;

--- a/scripts/espo_crm/translate_summarize_per_item_reponse_to_ouput
+++ b/scripts/espo_crm/translate_summarize_per_item_reponse_to_ouput
@@ -1,0 +1,56 @@
+// Script for translating reponse to output string for summarize per item feature in EspoCRM
+
+$response = $_lastHttpResponseBody;
+
+// Get the full list of summaries
+$summariesList = json\retrieve($response, 'summaries');
+
+// Initialize loop variables
+$finalString = '';
+$i = 0;
+$count = array\length($summariesList);
+
+// Loop through every summary item
+while ($i < $count) {
+    // Extract fields for the current index
+    $backendID = array\at($$backendIDs, $i);
+    $feedbackID = json\retrieve($response, string\concatenate('summaries.', $i, '.id'));
+    $title = json\retrieve($response, string\concatenate('summaries.', $i, '.title'));
+    $summary = json\retrieve($response, string\concatenate('summaries.', $i, '.summary'));
+    $score = json\retrieve($response, string\concatenate('summaries.', $i, '.quality_score'));
+
+    // Determine the Visual Dot Rating
+    $dots = '○○○○○';
+    if ($score >= 0.9) { $dots = '●●●●●'; }
+    else if ($score >= 0.7) { $dots = '●●●●○'; }
+    else if ($score >= 0.5) { $dots = '●●●○○'; }
+    else if ($score >= 0.3) { $dots = '●●○○○'; }
+    else if ($score >= 0.1) { $dots = '●○○○○'; }
+
+    // Format the Percentage
+    $numericScore = $score + 0; // Type casting trick
+    $percentageValue = $numericScore * 100;
+    $percent = string\concatenate(number\format($percentageValue, 0, '.', ''), '%');
+    
+    // Build the "Executive" Block
+    $itemBlock = string\concatenate(
+        "Feedback-ID:             ", $feedbackID, "\n",
+        "Backend-ID:             ", $backendID, "\n",
+        "QUALITY:        ", $dots, " ", $percent, "\n",
+        "TITLE:          ", $title, "\n",
+        "SUMMARY:        \n", $summary, "\n",
+        "------------------------------------------------------------\n\n"
+    );
+
+    // Append to the master string
+    $finalString = string\concatenate($finalString, $itemBlock);
+    
+    // Set feedback item summary description attribute
+    record\update("CFeedbackData", $backendID, "descriptionSummary", $itemBlock);
+
+    // Update counter
+    $i = $i + 1;
+}
+
+// Output the result to your field
+modelResponse = $finalString;


### PR DESCRIPTION
## Summary

Adds four EspoCRM scripts that integrate the summarize endpoints of the QFA API into EspoCRM workflows:

- **`set_summarize_aggregate_payload`** — builds the request payload for the `summarize_aggregate` endpoint by looping over related feedback records and constructing the JSON body
- **`set_summarize_per_item_payload`** — same for the `summarize` (per-item) endpoint
- **`translate_summarize_aggregate_reponse_to_ouput`** — parses the API response and formats the aggregate summary (title, quality score as dot-rating + %, summary text) into a readable output string
- **`translate_summarize_per_item_reponse_to_ouput`** — same for per-item summaries; also writes each item's summary back to the `descriptionSummary` field on the `CFeedbackData` record

These scripts are meant to be used as EspoCRM formula scripts in the workflow automation to call and process the QFA summarize features. Both payload scripts include a commented-out test payload for local workflow testing without needing real records.
