### PR TITLE
fix(espo): remove record update call that blocked summarize per item

### DIFF
--- a/scripts/espo_crm/translate_summarize_per_item_reponse_to_ouput
+++ b/scripts/espo_crm/translate_summarize_per_item_reponse_to_ouput
@@ -44,9 +44,6 @@ while ($i < $count) {
 
     // Append to the master string
     $finalString = string\concatenate($finalString, $recordBlock);
-    
-    // Set feedback record summary description attribute
-    record\update("CFeedbackData", $backendID, "descriptionSummary", $recordBlock);
 
     // Update counter
     $i = $i + 1;


### PR DESCRIPTION
## Summary

- Removes a `record\update` call inside the Espo CRM formula script that was left over from a previous experimentation and caused the summarize-per-item feature to fail silently on Espo Dev.

## Notes

I was unable to reproduce issue #88; this fix addresses a separate problem I did encounter on Espo Dev.
