### PR TITLE
fix(summarize): pin record IDs from request instead of trusting LLM output

### DIFF
--- a/src/qfa/api/routes.py
+++ b/src/qfa/api/routes.py
@@ -149,12 +149,14 @@ async def summarize(
     return ApiSummarizeResponse(
         summaries=[
             ApiFeedbackRecordSummary(
-                id=summary.id,
+                id=record.id,
                 title=summary.title,
                 summary=summary.summary,
                 quality_score=summary.quality_score,
             )
-            for summary in result.feedback_record_summaries
+            for record, summary in zip(
+                body.feedback_records, result.feedback_record_summaries
+            )
         ],
         used_anonymization=body.anonymize,
     )

--- a/src/qfa/api/routes.py
+++ b/src/qfa/api/routes.py
@@ -149,14 +149,12 @@ async def summarize(
     return ApiSummarizeResponse(
         summaries=[
             ApiFeedbackRecordSummary(
-                id=record.id,
+                id=summary.id,
                 title=summary.title,
                 summary=summary.summary,
                 quality_score=summary.quality_score,
             )
-            for record, summary in zip(
-                body.feedback_records, result.feedback_record_summaries
-            )
+            for summary in result.feedback_record_summaries
         ],
         used_anonymization=body.anonymize,
     )

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -387,6 +387,9 @@ class Orchestrator:
             quality_score = _parse_judge_quality_score(judge_response.structured)
 
             response.structured.quality_score = quality_score
+            response.structured.ids = tuple(
+                record.id for record in request.feedback_records
+            )
 
             if anonymize:
                 return_model_as_string = response.structured.model_dump_json()

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -318,22 +318,38 @@ class Orchestrator:
                 result = llm_completion.structured
 
             # Guard against LLM returning a different number of summaries than records submitted
-            if len(result.feedback_record_summaries) != len(request.feedback_records):
-                raise AnalysisError(
-                    f"LLM returned {len(result.feedback_record_summaries)} summaries"
-                    f" for {len(request.feedback_records)} requested feedback records."
-                )
-            # Replace LLM-generated IDs with the authoritative input record IDs
-            summaries_with_updated_id = tuple(
-                summary.model_copy(update={"id": record.id})
-                for record, summary in zip(
-                    request.feedback_records, result.feedback_record_summaries
-                )
-            )
-            result = result.model_copy(
-                update={"feedback_record_summaries": summaries_with_updated_id}
-            )
+            result = self._align_record_ids(request, result)
             return result
+
+    def _align_record_ids(
+        self, request: SummaryRequestModel, result: SummaryResultModel
+    ) -> SummaryResultModel:
+        """Align ids between input request and model output.
+
+        The model does not reliably reproduce the ids of the input records in its
+        output. This function:
+        1. checks that the number of records matches between intput and output
+        2. copies the ids from the input records into to output records.
+
+        Assumptions:
+        * the order of the model output matches the input.
+        """
+        if len(result.feedback_record_summaries) != len(request.feedback_records):
+            raise AnalysisError(
+                f"LLM returned {len(result.feedback_record_summaries)} summaries"
+                f" for {len(request.feedback_records)} requested feedback records."
+            )
+        # Replace LLM-generated IDs with the authoritative input record IDs
+        summaries_with_updated_id = tuple(
+            summary.model_copy(update={"id": record.id})
+            for record, summary in zip(
+                request.feedback_records, result.feedback_record_summaries
+            )
+        )
+        result = result.model_copy(
+            update={"feedback_record_summaries": summaries_with_updated_id}
+        )
+        return result
 
     async def summarize_aggregate(
         self,

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -311,11 +311,29 @@ class Orchestrator:
                 unanonymized_return_model_as_string = self._anonymizer.deanonymize(
                     return_model_as_string, anonymization_mapping
                 )
-                return SummaryResultModel.model_validate_json(
+                result = SummaryResultModel.model_validate_json(
                     unanonymized_return_model_as_string
                 )
+            else:
+                result = llm_completion.structured
 
-            return llm_completion.structured
+            # Guard against LLM returning a different number of summaries than records submitted
+            if len(result.feedback_record_summaries) != len(request.feedback_records):
+                raise AnalysisError(
+                    f"LLM returned {len(result.feedback_record_summaries)} summaries"
+                    f" for {len(request.feedback_records)} requested feedback records."
+                )
+            # Replace LLM-generated IDs with the authoritative input record IDs
+            summaries_with_updated_id = tuple(
+                summary.model_copy(update={"id": record.id})
+                for record, summary in zip(
+                    request.feedback_records, result.feedback_record_summaries
+                )
+            )
+            result = result.model_copy(
+                update={"feedback_record_summaries": summaries_with_updated_id}
+            )
+            return result
 
     async def summarize_aggregate(
         self,


### PR DESCRIPTION
## Summary
- Per-item summarize: route handler now zips request records with result summaries so `id` always comes from the caller, not the LLM
- Summarize-aggregate: orchestrator overrides the `ids` field after the LLM call for the same reason

## Why
Some models (e.g. Mistral) return wrong or missing IDs — either echoing sequential numbers (`1`, `2`) or the raw text content of the records (like daan's contact info haha). This caused EspoCRM to receive incorrect IDs, breaking record updates.



