### PR TITLE
refactor(tests): inherit ports explicitly in test doubles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,18 @@ Hexagonal architecture. Key concepts:
 - Driven adapters (LLM provider, anonymisation) sit behind ports
   declared in `qfa.domain.ports` — for example `LLMPort` and
   `AnonymizationPort` — so implementations can be swapped.
-- **Adapter classes must explicitly inherit from their port** (e.g.
-  `class LiteLLMClient(LLMPort):`, `class PresidioAnonymizer(AnonymizationPort):`).
-  Although Python `Protocol`s support structural typing without
-  inheritance, the explicit base class makes the port↔adapter
-  relationship discoverable in IDEs ("go to definition" jumps to the
-  contract) and signals intent to readers. Structural conformance is
-  reserved for ad-hoc test fakes that don't need to be navigable as
-  port implementations.
+- **Every class that implements a port must explicitly inherit from it
+  — by default, this applies to production adapters *and* test
+  doubles** (e.g. `class LiteLLMClient(LLMPort):`,
+  `class PresidioAnonymizer(AnonymizationPort):`,
+  `class FakeLLMPort(LLMPort):`). Although Python `Protocol`s support
+  structural typing without inheritance, the explicit base class makes
+  the port↔adapter relationship discoverable in IDEs ("go to
+  definition" jumps to the contract) and signals intent to readers.
+  Skipping the inheritance is reserved for genuinely ad-hoc cases
+  (e.g. one-line `unittest.mock.MagicMock(spec=LLMPort)` usages, which
+  enforce conformance via `spec=`) and should be the exception, not
+  the default.
 - API calls are authenticated via API keys.
 
 Layer rules are enforced by `import-linter` contracts in

--- a/docs/adr/002-protocol-based-ports.md
+++ b/docs/adr/002-protocol-based-ports.md
@@ -20,8 +20,12 @@ method.
 
 ## Decision
 
-Use `typing.Protocol` for both `LLMPort` and `OrchestratorPort`.
-Implementation explicitly inherit the Port protocol class.
+Use `typing.Protocol` for port declarations. **Every class that
+implements a port — production adapter or test double — must
+explicitly inherit from the Port protocol class.** Skipping the
+inheritance is reserved for genuinely ad-hoc cases such as
+`unittest.mock.MagicMock(spec=LLMPort)`, where `spec=` already
+enforces conformance.
 
 ## Options Considered
 
@@ -48,9 +52,13 @@ Implementation explicitly inherit the Port protocol class.
 ## Consequences
 
 - Port definitions in `domain/ports.py` are `Protocol` classes.
-- Adapter classes DO inherit from ports.
+- Adapter classes (production) **and test doubles** that implement a
+  port DO inherit from it.
 - Type checkers verify conformance. Tests verify behavior.
-- Adding a new adapter requires matching the protocol's method signature.
+- Adding a new port implementation requires matching the protocol's
+  method signatures and declaring the inheritance.
+- `MagicMock(spec=Port)` remains the recommended ad-hoc exception
+  when a one-shot mock is clearer than a named class.
 
 ## Participants
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -93,7 +93,7 @@ uv run pytest tests/integration/test_db_postgres.py   # specific file
 ## Coding style and conventions
 
 - **Follow the [project guidelines](https://github.com/rodekruis/qualitative-feedback-analysis/blob/main/AGENTS.md).** They cover package management (`uv`, not `pip`), commit messages (conventional commits), and the hexagonal layer rules.
-- **Every adapter explicitly inherits from its port.** Even though Python `Protocol`s support structural typing, we require `class LiteLLMClient(LLMPort):` and `class PresidioAnonymizer(AnonymizationPort):` so that "go to definition" in an IDE jumps from adapter to contract. Structural conformance is reserved for ad-hoc test fakes. See [Components](../architecture/03-components.md) for the full ports/adapters layout.
+- **Every class that implements a port explicitly inherits from it — production adapters *and* test doubles.** Even though Python `Protocol`s support structural typing, we require `class LiteLLMClient(LLMPort):`, `class PresidioAnonymizer(AnonymizationPort):`, and `class FakeLLMPort(LLMPort):` so that "go to definition" in an IDE jumps from any port impl to its contract. Skipping the inheritance is reserved for genuinely ad-hoc cases (e.g. one-shot `MagicMock(spec=Port)` instances, where `spec=` already enforces conformance). See [Components](../architecture/03-components.md) for the full ports/adapters layout.
 - **Import directions are enforced.** `qfa.domain` must not import third-party infra (`litellm`, `presidio_*`, `fastapi`, ...); `qfa.services` may only import `qfa.domain`; the composition root in `qfa.api.app` is the only place that wires concrete adapters into ports. `make lint` runs `lint-imports` to enforce this.
 
 ## Where to go next

--- a/tests/adapters/test_tracking_llm.py
+++ b/tests/adapters/test_tracking_llm.py
@@ -14,12 +14,13 @@ from qfa.domain.models import (
     LLMResponse,
     Operation,
 )
+from qfa.domain.ports import LLMPort, UsageRepositoryPort
 from qfa.services.call_context import call_scope
 
 pytestmark = pytest.mark.asyncio
 
 
-class FakeLLMPort:
+class FakeLLMPort(LLMPort):
     """Test double for LLMPort. Returns a queued response or raises."""
 
     def __init__(self) -> None:
@@ -52,7 +53,7 @@ class FakeLLMPort:
         return self._next_response
 
 
-class FakeUsageRepository:
+class FakeUsageRepository(UsageRepositoryPort):
     """Test double for UsageRepositoryPort.record_call."""
 
     def __init__(self) -> None:
@@ -210,7 +211,7 @@ async def test_recording_failure_during_error_path_still_propagates_original():
             )
 
 
-class _FlakyRepo:
+class _FlakyRepo(UsageRepositoryPort):
     """Fails with ``exc`` for the first ``fail_times`` attempts, then succeeds."""
 
     def __init__(self, exc: Exception, fail_times: int) -> None:

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -37,12 +37,12 @@ from qfa.domain.models import (
     TokenStats,
     UsageStats,
 )
-from qfa.domain.ports import UsageRepositoryPort
+from qfa.domain.ports import AuthManagementPort, UsageRepositoryPort
 from qfa.domain.sensitivity_types import SensitivityType
 from qfa.services.auth_orchestrator import AuthOrchestrator
 
 
-class FakeAuthManagementPort:
+class FakeAuthManagementPort(AuthManagementPort):
     """Fake auth-management adapter for API tests."""
 
     def __init__(self) -> None:

--- a/tests/api/test_auth_routes.py
+++ b/tests/api/test_auth_routes.py
@@ -4,16 +4,25 @@ import httpx
 import pytest
 import pytest_asyncio
 
+from qfa.domain import AuthenticationError, TenantApiKey
 from qfa.domain.errors import KeyAlreadyExistsError, TenantNotFoundError
-from qfa.domain.models import AuthKeyInfo, KeyCreationResponse, TenantApiKey, TenantInfo
+from qfa.domain.models import AuthKeyInfo, KeyCreationResponse, TenantInfo
+from qfa.services.auth_orchestrator import AuthOrchestrator
 
 from .conftest import FAKE_API_KEY, FAKE_SUPERUSER_KEY
 
 
-class RecordingAuthOrchestrator:
-    """Auth orchestrator test double with call recording."""
+class RecordingAuthOrchestrator(AuthOrchestrator):
+    """Auth orchestrator test double with call recording.
+
+    Inherits from :class:`AuthOrchestrator` so the type checker enforces
+    LSP-compatible overrides — any signature drift in the real service
+    will fail ``ty check`` here.
+    """
 
     def __init__(self, api_keys: list[TenantApiKey]) -> None:
+        # Deliberately skip super().__init__: the spy does not wire real
+        # auth-lookup or auth-management ports — its methods are overridden.
         self._api_keys = api_keys
         self.add_tenant_calls: list[dict] = []
         self.delete_tenant_calls: list[str] = []
@@ -27,11 +36,11 @@ class RecordingAuthOrchestrator:
         self.raise_on_add_key: Exception | None = None
         self.raise_on_delete_key: Exception | None = None
 
-    async def validate_api_key(self, provided_key: str) -> TenantApiKey | None:
-        for api_key in self._api_keys:
-            if api_key.matches_key(provided_key):
-                return api_key
-        return None
+    async def validate_api_key(self, api_key: str) -> TenantApiKey:
+        for known_key in self._api_keys:
+            if known_key.matches_key(api_key):
+                return known_key
+        raise AuthenticationError("API key does not match any known key.")
 
     async def add_tenant(
         self,

--- a/tests/api/test_usage_routes.py
+++ b/tests/api/test_usage_routes.py
@@ -13,6 +13,7 @@ from qfa.domain.models import (
     TokenStats,
     UsageStats,
 )
+from qfa.domain.ports import UsageRepositoryPort
 
 FAKE_API_KEY = "test-key-abc123"
 FAKE_SUPERUSER_KEY = "superuser-key-xyz789"
@@ -34,7 +35,7 @@ def _make_usage_stats(tenant_id: str | None = "tenant-test", total_calls: int = 
     )
 
 
-class FakeUsageRepository:
+class FakeUsageRepository(UsageRepositoryPort):
     def __init__(self, stats=None, all_stats=None):
         self._stats = stats
         self._all_stats = all_stats or []
@@ -152,7 +153,7 @@ class TestUsageAllEndpoint:
         assert resp.status_code == 403
 
 
-class _UnavailableUsageRepository:
+class _UnavailableUsageRepository(UsageRepositoryPort):
     """Fake repo whose reads raise ``UsageRepositoryUnavailableError``.
 
     Models the wired-but-unreachable case.

--- a/tests/services/test_orchestrator.py
+++ b/tests/services/test_orchestrator.py
@@ -21,6 +21,7 @@ from qfa.domain.models import (
     SummaryRequestModel,
     SummaryResultModel,
 )
+from qfa.domain.ports import AnonymizationPort, LLMPort
 from qfa.domain.sensitivity_types import SensitivityType
 from qfa.services.orchestrator import Orchestrator
 from qfa.settings import OrchestratorSettings
@@ -144,7 +145,7 @@ def _past_deadline():
     return datetime.now(tz=UTC) - timedelta(seconds=10)
 
 
-class FakeLLMPort:
+class FakeLLMPort(LLMPort):
     """A fake LLM port that returns configurable responses or raises errors."""
 
     def __init__(self, responses=None, errors=None):
@@ -182,7 +183,7 @@ class FakeLLMPort:
         return _make_llm_response(structured=_make_analysis_result())
 
 
-class FakeAnonymizer:
+class FakeAnonymizer(AnonymizationPort):
     """No-op anonymiser for tests: returns text unchanged with empty mapping."""
 
     def anonymize(self, text):


### PR DESCRIPTION
## Summary

- Tighten the project's port-inheritance rule: explicit inheritance is now the **default for every class that implements a port**, including test doubles. Only genuinely ad-hoc cases (e.g. `MagicMock(spec=Port)`) skip it.
- Updates `AGENTS.md`, `docs/adr/002-protocol-based-ports.md`, and `docs/development/index.md` to state the new default consistently.
- Adds the missing `(LLMPort)` / `(UsageRepositoryPort)` / `(AnonymizationPort)` / `(AuthManagementPort)` bases on 8 test fakes that previously relied on structural conformance.
- `RecordingAuthOrchestrator` in `tests/api/test_auth_routes.py` now subclasses the concrete `AuthOrchestrator` service so `ty` enforces LSP-compatible overrides — signature drift in the service fails the test build. This also surfaced (and fixed) a latent drift where the spy's `validate_api_key` mirrored the lookup *port* (returned `None` on miss) instead of the service contract (raises `AuthenticationError`).

## Test plan

- [x] `uv run pytest tests -q` — 287 passed
- [x] `uv run ruff format --check` / `uv run ruff check` — clean
- [x] `uv run ty check` — clean
- [x] `uv run lint-imports` — 3/3 contracts kept
- [x] `uv run pytest --doctest-modules src` — no doctests collected (parity with main)
