### PR TITLE
feat: add pretty_output field to summarize responses

### DIFF
--- a/scripts/espo_crm/translate_summarize_aggregate_reponse_to_ouput
+++ b/scripts/espo_crm/translate_summarize_aggregate_reponse_to_ouput
@@ -1,44 +1,6 @@
-// Script for translating reponse to output string for summarize aggregate feature in EspoCRM
+// Script for translating response to output string for summarize aggregate feature in EspoCRM
+// The QFA backend now returns a pre-formatted pretty_output field on the summary object.
 
 $response = $_lastHttpResponseBody;
 
-// Extract aggregate summary fields                                                 
-$title = json\retrieve($response, 'summary.title');                                 
-$summary = json\retrieve($response, 'summary.summary');                             
-$score = json\retrieve($response, 'summary.quality_score');
-
-// Build IDs string from the ids array       
-$idsList = json\retrieve($response, 'summary.ids');
-$idsCount = array\length($idsList);             
-$idsString = '';
-$j = 0;
-while ($j < $idsCount) {                                                       
-  $id = array\at($idsList, $j);
-  if ($j > 0) { $idsString = string\concatenate($idsString, ', '); }
-  $idsString = string\concatenate($idsString, $id);                  
-  $j = $j + 1;
-}  
-  
-// Determine the Visual Dot Rating                                                     
-$dots = '○○○○○';
-if ($score >= 0.9) { $dots = '●●●●●'; }                                                 
-else if ($score >= 0.7) { $dots = '●●●●○'; }
-else if ($score >= 0.5) { $dots = '●●●○○'; }                                            
-else if ($score >= 0.3) { $dots = '●●○○○'; }
-else if ($score >= 0.1) { $dots = '●○○○○'; }                                                                                                            
-// Format the Percentage
-$numericScore = $score + 0; // Type casting trick                                       
-$percentageValue = $numericScore * 100;
-$percent = string\concatenate(number\format($percentageValue, 0, '.', ''), '%');
-
-// Build the aggregate block
-$finalString = string\concatenate( 
-    "IDs:            ", $idsString, "\n",
-    "QUALITY:        ", $dots, " ", $percent, "\n",
-    "TITLE:          ", $title, "\n",
-    "SUMMARY:        \n", $summary, "\n",                                               
-    "------------------------------------------------------------\n\n"
-);                                                                                      
-                
-// Output the result to your field
-modelResponse = $finalString;
+modelResponse = json\retrieve($response, 'summary.pretty_output');

--- a/scripts/espo_crm/translate_summarize_per_item_reponse_to_ouput
+++ b/scripts/espo_crm/translate_summarize_per_item_reponse_to_ouput
@@ -1,53 +1,18 @@
-// Script for translating reponse to output string for summarize per record feature in EspoCRM
+// Script for translating response to output string for summarize per record feature in EspoCRM
+// The QFA backend now returns a pre-formatted pretty_output field per summary record.
+// This script concatenates those fields into a single output string.
 
 $response = $_lastHttpResponseBody;
 
-// Get the full list of summaries
 $summariesList = json\retrieve($response, 'summaries');
-
-// Initialize loop variables
+$count = array\length($summariesList);
 $finalString = '';
 $i = 0;
-$count = array\length($summariesList);
 
-// Loop through every summary
 while ($i < $count) {
-    // Extract fields for the current index
-    $backendID = array\at($$backendIDs, $i);
-    $feedbackID = json\retrieve($response, string\concatenate('summaries.', $i, '.id'));
-    $title = json\retrieve($response, string\concatenate('summaries.', $i, '.title'));
-    $summary = json\retrieve($response, string\concatenate('summaries.', $i, '.summary'));
-    $score = json\retrieve($response, string\concatenate('summaries.', $i, '.quality_score'));
-
-    // Determine the Visual Dot Rating
-    $dots = '○○○○○';
-    if ($score >= 0.9) { $dots = '●●●●●'; }
-    else if ($score >= 0.7) { $dots = '●●●●○'; }
-    else if ($score >= 0.5) { $dots = '●●●○○'; }
-    else if ($score >= 0.3) { $dots = '●●○○○'; }
-    else if ($score >= 0.1) { $dots = '●○○○○'; }
-
-    // Format the Percentage
-    $numericScore = $score + 0; // Type casting trick
-    $percentageValue = $numericScore * 100;
-    $percent = string\concatenate(number\format($percentageValue, 0, '.', ''), '%');
-    
-    // Build the "Executive" Block
-    $recordBlock = string\concatenate(
-        "Feedback-ID:             ", $feedbackID, "\n",
-        "Backend-ID:             ", $backendID, "\n",
-        "QUALITY:        ", $dots, " ", $percent, "\n",
-        "TITLE:          ", $title, "\n",
-        "SUMMARY:        \n", $summary, "\n",
-        "------------------------------------------------------------\n\n"
-    );
-
-    // Append to the master string
-    $finalString = string\concatenate($finalString, $recordBlock);
-
-    // Update counter
+    $block = json\retrieve($response, string\concatenate('summaries.', $i, '.pretty_output'));
+    $finalString = string\concatenate($finalString, $block, "\n\n");
     $i = $i + 1;
 }
 
-// Output the result to your field
 modelResponse = $finalString;

--- a/src/qfa/api/schemas.py
+++ b/src/qfa/api/schemas.py
@@ -9,7 +9,54 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, computed_field, model_validator
+
+_SEPARATOR = "------------------------------------------------------------"
+
+
+def _quality_dots(score: float) -> str:
+    if score >= 0.9:
+        return "●●●●●"
+    if 0.7 <= score < 0.9:
+        return "●●●●○"
+    if 0.5 <= score < 0.7:
+        return "●●●○○"
+    if 0.3 <= score < 0.5:
+        return "●●○○○"
+    if 0.1 <= score < 0.3:
+        return "●○○○○"
+    return "○○○○○"
+
+
+def _create_pretty_output(
+    *,
+    id: str | None = None,
+    ids: list[str] | None = None,
+    quality_score: float | None = None,
+    title: str | None = None,
+    summary: str | None = None,
+) -> str:
+    """Build a human-readable text block for display in EspoCRM.
+
+    All arguments are optional because this function is shared across endpoints;
+    each endpoint passes only the fields relevant to it. Omitted fields are
+    excluded from the output.
+    """
+    lines: list[str] = []
+    if id is not None:
+        lines.append(f"Feedback-ID:    {id}")
+    if ids is not None:
+        lines.append(f"IDs:            {', '.join(ids)}")
+    if quality_score is not None:
+        dots = _quality_dots(quality_score)
+        percent = f"{round(quality_score * 100)}%"
+        lines.append(f"QUALITY:        {dots} {percent}")
+    if title is not None:
+        lines.append(f"TITLE:          {title}")
+    if summary is not None:
+        lines.append(f"SUMMARY:\n{summary}")
+    lines.append(_SEPARATOR)
+    return "\n".join(lines)
 
 
 def _assign_codes_request_examples() -> list[dict[str, Any]]:
@@ -246,6 +293,17 @@ class ApiFeedbackRecordSummary(BaseModel):
         description="Judge score for summary quality in the range 0.0-1.0.",
     )
 
+    @computed_field(description="Human-readable formatted output string.")
+    @property
+    def pretty_output(self) -> str:
+        """Human-readable formatted output string."""
+        return _create_pretty_output(
+            id=self.id,
+            quality_score=self.quality_score,
+            title=self.title,
+            summary=self.summary,
+        )
+
 
 class ApiSummarizeResponse(BaseModel):
     """Response body for the ``POST /v1/summarize`` endpoint."""
@@ -271,6 +329,17 @@ class ApiAggregateSummary(BaseModel):
         le=1.0,
         description="Judge score for summary quality in the range 0.0-1.0.",
     )
+
+    @computed_field(description="Human-readable formatted output string.")
+    @property
+    def pretty_output(self) -> str:
+        """Human-readable formatted output string."""
+        return _create_pretty_output(
+            ids=self.ids,
+            quality_score=self.quality_score,
+            title=self.title,
+            summary=self.summary,
+        )
 
 
 class ApiSummarizeAggregateResponse(BaseModel):

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -428,14 +428,14 @@ class TestErrorMapping:
                 headers=_auth_header(),
             )
         assert resp.status_code == 200
-        assert resp.json()["summaries"] == [
-            {
-                "id": "custom-1",
-                "title": "Custom title",
-                "summary": "- Custom point",
-                "quality_score": 0.75,
-            }
-        ]
+        summaries = resp.json()["summaries"]
+        assert len(summaries) == 1
+        s = summaries[0]
+        assert s["id"] == "custom-1"
+        assert s["title"] == "Custom title"
+        assert s["summary"] == "- Custom point"
+        assert s["quality_score"] == 0.75
+        assert "pretty_output" in s
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
Closes #101

Moves EspoCRM output formatting from formula scripts into the API layer. The `pretty_output` computed field is added to `ApiFeedbackRecordSummary` and `ApiAggregateSummary`, so EspoCRM scripts become thin one-liners that simply read the pre-formatted field.