### PR TITLE
feat(embedding): configurable model family, default multilingual-e5-base

### DIFF
--- a/.devcontainer/dotfiles/statusline-command.sh
+++ b/.devcontainer/dotfiles/statusline-command.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Ensure a UTF-8 locale so bash ${#var} counts characters, not bytes.
+# This matters for the → glyph used in reset suffixes.
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
 
 # Read JSON input from stdin
 input=$(cat)
@@ -6,74 +10,252 @@ input=$(cat)
 # Extract values
 model=$(echo "$input" | jq -r '.model.display_name')
 style=$(echo "$input" | jq -r '.output_style.name // "default"')
-cost=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
 
 # Read effort level from settings file (default if missing)
 effort=$(jq -r '.effortLevel // "default"' ~/.claude/settings.json 2>/dev/null || echo "default")
 
-# Build the status line: model (effort) | output style
-status="$model ($effort) | output style: $style"
+# Build the status line: model (effort) | style
+status="$model ($effort) | $style"
 
-# Add session cost
-cost_fmt=$(printf "$%.2f" "$cost")
-status="$status | $cost_fmt"
+# ---------------------------------------------------------------------------
+# inline_bar LABEL PCT [RESET_SUFFIX]
+#
+# Renders a bracketed progress bar where the fill boundary is shown via two
+# distinct 256-color backgrounds rather than block characters:
+#   - filled portion  → dark-gray background  (256-color index BG_FILLED)
+#   - unfilled portion → light-gray background (256-color index BG_EMPTY)
+# Default foreground color is preserved throughout (\033[48;5;Nm sets bg only;
+# \033[49m resets bg only).  Brackets [ ] sit outside all color escapes.
+#
+# Minimum inner width: MIN_WIDTH printable chars (padded with trailing spaces).
+# This prevents very short segments from being hard to read as progress bars.
+#
+# Split arithmetic uses bash integer math with round-half-up:
+#   split = (pct * total + 50) / 100  — then clamped to [1, total-1] when
+# partially filled so the boundary is always visible.
+# bash ${#var} counts Unicode code points in a UTF-8 locale (set at top of
+# script), so multi-byte chars like → count as 1 — safe for split indexing.
+#
+# Color indices to tweak:
+#   BG_FILLED=236  — xterm-256 dark  gray (r48  g48  b48)
+#   BG_EMPTY =250  — xterm-256 light gray (r188 g188 b188)
+# ---------------------------------------------------------------------------
+inline_bar() {
+    local label="$1"
+    local pct="$2"
+    local reset_suffix="${3:-}"
 
-# Add context percentage with progress bar if available
+    # 256-color background indices — adjust here to re-tune the palette
+    local BG_FILLED=236   # dark  gray: filled   portion
+    local BG_EMPTY=250    # light gray: unfilled portion
+    local MIN_WIDTH=10    # minimum printable chars inside the brackets
+
+    # Build the inner text (no ANSI, just printable chars)
+    local pct_int
+    pct_int=$(printf "%.0f" "$pct")
+    local inner="${label} ${pct_int}%"
+    [ -n "$reset_suffix" ] && inner="${inner} ${reset_suffix}"
+
+    # Pad inner to at least MIN_WIDTH with trailing spaces, then add one
+    # space of breathing room on each side → padded is always ≥ MIN_WIDTH+2
+    local inner_len=${#inner}
+    if [ "$inner_len" -lt "$MIN_WIDTH" ]; then
+        local pad=$(( MIN_WIDTH - inner_len ))
+        local spaces
+        printf -v spaces '%*s' "$pad" ''
+        inner="${inner}${spaces}"
+    fi
+    local padded=" ${inner} "
+    local total=${#padded}
+
+    # Compute split point: how many chars of $padded to paint in BG_FILLED.
+    # Three cases:
+    #   pct==0   → split=0 (nothing filled)
+    #   pct==100 → split=total (fully filled)
+    #   else     → round-half-up, then clamp to [1, total-1]
+    #              round-half-up in integer arithmetic: (pct*total + 50) / 100
+    #              min=1: with two-tone backgrounds a 1-char dark cell is visible
+    #              max=total-1: trailing space stays light until truly 100%
+    local split
+    if [ "$pct_int" -eq 0 ]; then
+        split=0
+    elif [ "$pct_int" -ge 100 ]; then
+        split=$total
+    else
+        split=$(( (pct_int * total + 50) / 100 ))
+        [ "$split" -lt 1 ] && split=1
+        [ "$split" -ge "$total" ] && split=$(( total - 1 ))
+    fi
+
+    local filled_text="${padded:0:$split}"
+    local empty_text="${padded:$split}"
+
+    # Structure: [  BG_FILLED<filled_text>  BG_EMPTY<empty_text>  RESET_BG  ]
+    printf '[%b%s%b%s%b]' \
+        "\033[48;5;${BG_FILLED}m" "${filled_text}" \
+        "\033[48;5;${BG_EMPTY}m"  "${empty_text}" \
+        "\033[49m"
+}
+
+# Format a Unix epoch reset timestamp for the 5h limit: local time-of-day "→HH:MM"
+format_reset_5h() {
+    local epoch="$1"
+    date -d "@${epoch}" "+→%H:%M" 2>/dev/null || true
+}
+
+# Format a Unix epoch reset timestamp for the 7d limit: "→Nd HH:MM" or "→Www HH:MM"
+# Uses "→Nd HH:MM" when reset is ≥24h away (shorter), otherwise "→Www HH:MM"
+format_reset_7d() {
+    local epoch="$1"
+    local now
+    now=$(date +%s)
+    local diff=$(( epoch - now ))
+    if [ "$diff" -le 0 ]; then
+        date -d "@${epoch}" "+→%H:%M" 2>/dev/null || true
+    elif [ "$diff" -ge 86400 ]; then
+        local days=$(( diff / 86400 ))
+        local time_part
+        time_part=$(date -d "@${epoch}" "+%H:%M" 2>/dev/null || true)
+        printf "→%dd %s" "$days" "$time_part"
+    else
+        date -d "@${epoch}" "+→%a %H:%M" 2>/dev/null || true
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Git worktree segment
+#
+# Shows main worktree branch and, when running inside a secondary worktree,
+# the current worktree basename + its branch.
+# Format (secondary): [ main:<branch> | wt:<basename>@<branch> ]
+# Format (main):      [ main:<branch> ]
+# Detached HEAD: shows short SHA (7 chars) prefixed with #
+#
+# Cached in /tmp for 2 seconds, keyed by uid + repo root, so separate repos
+# and separate users each get their own cache entry.
+# ---------------------------------------------------------------------------
+git_segment() {
+    # Resolve current worktree root — if this fails we're not in a git repo
+    local cwd_root
+    cwd_root=$(git rev-parse --show-toplevel 2>/dev/null) || return
+
+    # Cache key: uid + sanitised repo root path
+    local cache_key
+    cache_key=$(printf '%s' "$cwd_root" | tr -cs 'a-zA-Z0-9' '_')
+    local cache_file="/tmp/claude-git-wt-$(id -u)-${cache_key}.txt"
+    local now
+    now=$(date +%s)
+
+    # Serve from cache if it exists and is <2 seconds old
+    if [ -f "$cache_file" ]; then
+        local age=$(( now - $(stat -c %Y "$cache_file" 2>/dev/null || echo 0) ))
+        if [ "$age" -lt 2 ]; then
+            cat "$cache_file"
+            return
+        fi
+    fi
+
+    # Parse git worktree list --porcelain.
+    # Records are separated by blank lines; the first record is always the
+    # main worktree.  We track two records: main (index 0) and whichever
+    # record's worktree path matches cwd_root.
+    local main_path="" main_branch="" main_sha="" main_detached=0
+    local cur_path=""  cur_branch=""  cur_sha=""  cur_detached=0
+    local record_index=0
+    local in_path="" in_branch="" in_sha="" in_detached=0
+
+    # Inline flush: called on blank line or after the final record.
+    # Reads in_* variables, writes main_* / cur_* as appropriate.
+    _gs_flush() {
+        [ -z "$in_path" ] && return
+        if [ "$record_index" -eq 0 ]; then
+            main_path="$in_path"; main_branch="$in_branch"
+            main_sha="$in_sha";   main_detached=$in_detached
+        fi
+        if [ "$in_path" = "$cwd_root" ]; then
+            cur_path="$in_path"; cur_branch="$in_branch"
+            cur_sha="$in_sha";   cur_detached=$in_detached
+        fi
+        record_index=$(( record_index + 1 ))
+        in_path=""; in_branch=""; in_sha=""; in_detached=0
+    }
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            worktree\ *)  in_path="${line#worktree }" ;;
+            branch\ *)    in_branch="${line#branch refs/heads/}" ;;
+            HEAD\ *)      in_sha="${line#HEAD }" ;;
+            detached)     in_detached=1 ;;
+            "")           _gs_flush ;;
+        esac
+    done < <(git worktree list --porcelain 2>/dev/null)
+    _gs_flush   # flush final record (no trailing blank line in porcelain output)
+    unset -f _gs_flush
+
+    # Nothing parsed — git not available or not a repo
+    [ -z "$main_path" ] && return
+
+    # Format a ref for display: branch name, or #<short-sha> if detached.
+    local main_ref cur_ref
+    if [ "$main_detached" -eq 1 ]; then
+        main_ref="#${main_sha:0:7}"
+    elif [ -n "$main_branch" ]; then
+        main_ref="$main_branch"
+    else
+        main_ref="${main_sha:0:7}"
+    fi
+
+    local result
+    if [ "$cwd_root" = "$main_path" ] || [ -z "$cur_path" ]; then
+        # Standing in the main worktree, or current root not found in list
+        result="main:${main_ref}"
+    else
+        if [ "$cur_detached" -eq 1 ]; then
+            cur_ref="#${cur_sha:0:7}"
+        elif [ -n "$cur_branch" ]; then
+            cur_ref="$cur_branch"
+        else
+            cur_ref="${cur_sha:0:7}"
+        fi
+        local wt_name
+        wt_name=$(basename "$cur_path")
+        result="main:${main_ref} | wt:${wt_name}@${cur_ref}"
+    fi
+
+    # Write to cache and emit
+    printf '[%s]' "$result" | tee "$cache_file"
+}
+
+git_seg=$(git_segment 2>/dev/null)
+
+# Add context percentage with inline bar if available
 used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
 if [ -n "$used" ]; then
-    bar_length=10
-    filled=$(printf "%.0f" $(echo "$used / 10" | bc -l))
-    if [ "$filled" -lt 0 ]; then filled=0; fi
-    if [ "$filled" -gt "$bar_length" ]; then filled=$bar_length; fi
-    empty=$((bar_length - filled))
-
-    bar=""
-    for ((i=0; i<filled; i++)); do bar="${bar}█"; done
-    for ((i=0; i<empty; i++)); do bar="${bar}░"; done
-
-    used_fmt=$(printf "%.0f" "$used")
-    status="$status | ctx [${bar}] ${used_fmt}%"
+    status="$status | $(inline_bar "ctx" "$used")"
 fi
 
-# Attempt to get session limits from claude usage command
-# Cache the result for 60 seconds to avoid repeated calls
-cache_file="/tmp/claude-usage-cache-$(whoami).txt"
-cache_timeout=60
+# Add subscription rate limits from JSON input (5-hour session and 7-day weekly)
+five_pct=$(echo "$input"   | jq -r '.rate_limits.five_hour.used_percentage // empty')
+five_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+week_pct=$(echo "$input"   | jq -r '.rate_limits.seven_day.used_percentage // empty')
+week_reset=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
 
-if [ -f "$cache_file" ]; then
-    cache_age=$(($(date +%s) - $(stat -c %Y "$cache_file" 2>/dev/null || echo 0)))
-    if [ "$cache_age" -gt "$cache_timeout" ]; then
-        rm -f "$cache_file"
-    fi
+if [ -n "$five_pct" ]; then
+    five_suffix=""
+    [ -n "$five_reset" ] && five_suffix=$(format_reset_5h "$five_reset")
+    status="$status | $(inline_bar "5h" "$five_pct" "$five_suffix")"
+fi
+if [ -n "$week_pct" ]; then
+    week_suffix=""
+    [ -n "$week_reset" ] && week_suffix=$(format_reset_7d "$week_reset")
+    status="$status | $(inline_bar "7d" "$week_pct" "$week_suffix")"
 fi
 
-if [ ! -f "$cache_file" ]; then
-    # Try to run claude usage and parse output
-    # Timeout after 1 second to avoid blocking
-    timeout 1s claude usage 2>/dev/null | grep -E "(Messages|Resets in)" > "$cache_file" 2>/dev/null || true
+# Emit line 1 (model/style/bars), then line 2 (git segment) only if present.
+# If Claude Code clips multi-line status to one row, move git_seg back to
+# line 1 by appending: status="$status | $git_seg" before the printf.
+if [ -n "$git_seg" ]; then
+    printf "%s\n%s\n" "$status" "$git_seg"
+else
+    printf "%s\n" "$status"
 fi
-
-# Parse cached usage info if available
-if [ -f "$cache_file" ] && [ -s "$cache_file" ]; then
-    daily_pct=$(grep -oP "Daily.*?\(\K[0-9]+(?=%\))" "$cache_file" 2>/dev/null || echo "")
-    hourly_pct=$(grep -oP "Hourly.*?\(\K[0-9]+(?=%\))" "$cache_file" 2>/dev/null || echo "")
-    reset_time=$(grep -oP "Resets in \K[^$]*" "$cache_file" 2>/dev/null | tr -d '\n' || echo "")
-
-    # Add to status line
-    if [ -n "$daily_pct" ] || [ -n "$hourly_pct" ]; then
-        limit_info=""
-        if [ -n "$hourly_pct" ]; then
-            limit_info="H:${hourly_pct}%"
-        fi
-        if [ -n "$daily_pct" ]; then
-            [ -n "$limit_info" ] && limit_info="$limit_info "
-            limit_info="${limit_info}D:${daily_pct}%"
-        fi
-        if [ -n "$reset_time" ]; then
-            limit_info="$limit_info (${reset_time})"
-        fi
-        status="$status | $limit_info"
-    fi
-fi
-
-echo "$status"

--- a/.env.example
+++ b/.env.example
@@ -20,16 +20,20 @@ LLM_API_VERSION=2024-05-01-preview
 # ORCHESTRATOR_RETRY_CAP_SECONDS=10.0
 # ORCHESTRATOR_CHARS_PER_TOKEN=4
 
- # ── Embedding (self-hosted BGE-M3 ONNX, mode=hierarchical) ───────────
- # Required for hierarchical analysis. Fetch the model once with:
- #   uv run python scripts/fetch_embedding_model.py
- # It downloads to the gitignored .models/ below and prints these exact
- # lines. Relative paths work because the server runs from the repo root and
- # the notebook anchors CWD to it. Production does NOT use this path — the
- # image bakes the model in at /app/models (see Dockerfile / ADR-014).
- EMBEDDING_MODEL_PATH=.models/bge-m3-onnx-int8/model_quantized.onnx
- EMBEDDING_TOKENIZER_PATH=.models/bge-m3-onnx-int8/tokenizer.json
- EMBEDDING_REVISION_HASH=2b34e84df040034d4b9eabb62383a87c18955822
+# ── Embedding (self-hosted ONNX, mode=hierarchical) ──────────────────
+# Required for hierarchical analysis. Fetch the default model (e5-base) once:
+#   uv run python scripts/fetch_embedding_model.py
+# (add --model bge-m3 / --model e5-small for the other artifacts). It
+# downloads to the gitignored .models/ below and prints these exact lines.
+# Relative paths work because the server runs from the repo root and the
+# notebook anchors CWD to it. Production does NOT use this path — the image
+# bakes the model in at /app/models (see Dockerfile / ADR-014).
+EMBEDDING_MODEL_PATH=.models/multilingual-e5-base/onnx/model_qint8_avx512_vnni.onnx
+EMBEDDING_TOKENIZER_PATH=.models/multilingual-e5-base/tokenizer.json
+EMBEDDING_REVISION_HASH=d128750597153bb5987e10b1c3493a34e5a4502a
+EMBEDDING_MODEL_KIND=e5
+EMBEDDING_DENSE_DIM=768
+EMBEDDING_MAX_TOKENS=512
 
 # ── Logging ──────────────────────────────────────────────────────────
 # LOGLEVEL=DEBUG

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,17 @@ LLM_API_VERSION=2024-05-01-preview
 # ORCHESTRATOR_RETRY_CAP_SECONDS=10.0
 # ORCHESTRATOR_CHARS_PER_TOKEN=4
 
+ # ── Embedding (self-hosted BGE-M3 ONNX, mode=hierarchical) ───────────
+ # Required for hierarchical analysis. Fetch the model once with:
+ #   uv run python scripts/fetch_embedding_model.py
+ # It downloads to the gitignored .models/ below and prints these exact
+ # lines. Relative paths work because the server runs from the repo root and
+ # the notebook anchors CWD to it. Production does NOT use this path — the
+ # image bakes the model in at /app/models (see Dockerfile / ADR-014).
+ EMBEDDING_MODEL_PATH=.models/bge-m3-onnx-int8/model_quantized.onnx
+ EMBEDDING_TOKENIZER_PATH=.models/bge-m3-onnx-int8/tokenizer.json
+ EMBEDDING_REVISION_HASH=2b34e84df040034d4b9eabb62383a87c18955822
+
 # ── Logging ──────────────────────────────────────────────────────────
 # LOGLEVEL=DEBUG
 # LOGLEVEL_3RDPARTY=WARNING

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Generated corpus fixtures: large, machine-produced by scripts/generate_corpus.py.
+# Mark as generated so GitHub collapses them in pull-request diffs and excludes
+# them from repository language statistics. They remain plain, diffable text in
+# normal git (no LFS) — this only changes how they are *presented* in review.
+fixtures/analyze_corpus.yaml linguist-generated=true
+fixtures/large_corpus.yaml linguist-generated=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-# Pinned revisions of the self-hosted ONNX embedders (ADR-014). Both models
-# are baked into the image so embeddings work on every deploy with no runtime
-# HuggingFace dependency; the runtime ENV below selects e5-base as the default
-# and BGE-M3 is one env override away. Each SHA resolves a moving HF `main` ref
-# to an immutable commit. To bump one: pick a newer commit, re-run the
-# cosine-validation e2e test, then update here AND in
+# Pinned revision of the self-hosted ONNX embedder (ADR-014). The default
+# model, multilingual-e5-base, is baked into the image so embeddings work on
+# every deploy with no runtime HuggingFace dependency. The SHA resolves a
+# moving HF `main` ref to an immutable commit. To bump it: pick a newer commit,
+# re-run the cosine-validation e2e test, then update here AND in
 # scripts/fetch_embedding_model.py (the MODELS registry) in lockstep.
-# Declared before the first FROM so both stages inherit them; changing one
-# busts the matching model-fetch layer cache and its runtime ENV together.
+# Declared before the first FROM so both stages inherit it; changing it busts
+# the model-fetch layer cache and its runtime ENV together.
+#
+# Only e5-base is baked. To run a different family (e.g. BGE-M3) fetch it into
+# the image — add a fetch step below using scripts/fetch_embedding_model.py
+# --model bge-m3 — and point the EMBEDDING_* env at it.
 ARG EMBEDDING_E5_REVISION=d128750597153bb5987e10b1c3493a34e5a4502a
-ARG EMBEDDING_BGE_M3_REVISION=2b34e84df040034d4b9eabb62383a87c18955822
 
 # ── Stage: fetch the embedding models ────────────────────────────────────
 # INTERIM: this fetches from HuggingFace at *build* time, pinned by revision.
@@ -18,7 +20,6 @@ ARG EMBEDDING_BGE_M3_REVISION=2b34e84df040034d4b9eabb62383a87c18955822
 # rest of the image is unaffected.
 FROM python:3.13-slim AS model
 ARG EMBEDDING_E5_REVISION
-ARG EMBEDDING_BGE_M3_REVISION
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /build
 COPY scripts/fetch_embedding_model.py .
@@ -28,26 +29,19 @@ RUN uv run --no-project --with "huggingface-hub>=1.10" \
         python fetch_embedding_model.py --model e5-base \
         --revision "${EMBEDDING_E5_REVISION}" \
         --dest /models/multilingual-e5-base
-RUN uv run --no-project --with "huggingface-hub>=1.10" \
-        python fetch_embedding_model.py --model bge-m3 \
-        --revision "${EMBEDDING_BGE_M3_REVISION}" \
-        --dest /models/bge-m3-onnx-int8
 
 # ── Runtime image ────────────────────────────────────────────────────────
 FROM python:3.13-slim
 ARG EMBEDDING_E5_REVISION
-ARG EMBEDDING_BGE_M3_REVISION
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
 # Model layer first: it's large and rarely changes, so keeping it above the
 # frequently-churning app code means it stays cached (and isn't re-pushed)
-# until a pinned revision changes. Both models are copied; the ENV below picks
-# e5-base as the default. To run BGE-M3 instead, override at deploy time:
-#   EMBEDDING_MODEL_PATH=/app/models/bge-m3-onnx-int8/model_quantized.onnx
-#   EMBEDDING_TOKENIZER_PATH=/app/models/bge-m3-onnx-int8/tokenizer.json
-#   EMBEDDING_REVISION_HASH=<the bge-m3 SHA>  EMBEDDING_MODEL_KIND=bge-m3
-#   EMBEDDING_DENSE_DIM=1024  (and unset EMBEDDING_MAX_TOKENS)
+# until the pinned revision changes. Only the default model (e5-base) is
+# baked; the ENV below points at it. To run a different family, bake it in
+# (add a fetch step in the model stage above) and override the EMBEDDING_*
+# env accordingly.
 COPY --from=model /models /app/models
 ENV EMBEDDING_MODEL_PATH=/app/models/multilingual-e5-base/onnx/model_qint8_avx512_vnni.onnx \
     EMBEDDING_TOKENIZER_PATH=/app/models/multilingual-e5-base/tokenizer.json \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,60 @@
-# Pinned revision of the self-hosted BGE-M3 ONNX-int8 embedder (ADR-014).
-# This is the HuggingFace repo gpahal/bge-m3-onnx-int8 at the tip of `main`
-# as of 2026-05-29 (resolved to its commit SHA so the pin is immutable —
-# `main` is a moving ref). To bump: pick a newer commit, re-run the
-# cosine-validation e2e test against official BAAI/bge-m3, then update here.
-# Declared before the first FROM so both stages inherit it; changing it busts
-# the model-fetch layer cache and the runtime ENV in lockstep.
-ARG EMBEDDING_REVISION=2b34e84df040034d4b9eabb62383a87c18955822
+# Pinned revisions of the self-hosted ONNX embedders (ADR-014). Both models
+# are baked into the image so embeddings work on every deploy with no runtime
+# HuggingFace dependency; the runtime ENV below selects e5-base as the default
+# and BGE-M3 is one env override away. Each SHA resolves a moving HF `main` ref
+# to an immutable commit. To bump one: pick a newer commit, re-run the
+# cosine-validation e2e test, then update here AND in
+# scripts/fetch_embedding_model.py (the MODELS registry) in lockstep.
+# Declared before the first FROM so both stages inherit them; changing one
+# busts the matching model-fetch layer cache and its runtime ENV together.
+ARG EMBEDDING_E5_REVISION=d128750597153bb5987e10b1c3493a34e5a4502a
+ARG EMBEDDING_BGE_M3_REVISION=2b34e84df040034d4b9eabb62383a87c18955822
 
-# ── Stage: fetch the embedding model ─────────────────────────────────────
-# Baked into the image so embeddings work on every deploy with no runtime
-# HuggingFace dependency (ADR-014: never fetch from HF at runtime).
-#
+# ── Stage: fetch the embedding models ────────────────────────────────────
 # INTERIM: this fetches from HuggingFace at *build* time, pinned by revision.
-# ADR-014 ultimately wants the artifact mirrored to an artifact store we
+# ADR-014 ultimately wants the artifacts mirrored to an artifact store we
 # control (e.g. an Azure Blob container) and pulled from there. When that
-# mirror exists, replace the fetch below with a COPY/download from it — the
+# mirror exists, replace the fetches below with a COPY/download from it — the
 # rest of the image is unaffected.
 FROM python:3.13-slim AS model
-ARG EMBEDDING_REVISION
+ARG EMBEDDING_E5_REVISION
+ARG EMBEDDING_BGE_M3_REVISION
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /build
 COPY scripts/fetch_embedding_model.py .
 # --no-project: don't try to resolve the repo's pyproject; --with pulls just
 # the one dependency the script needs into an ephemeral environment.
 RUN uv run --no-project --with "huggingface-hub>=1.10" \
-        python fetch_embedding_model.py \
-        --revision "${EMBEDDING_REVISION}" \
+        python fetch_embedding_model.py --model e5-base \
+        --revision "${EMBEDDING_E5_REVISION}" \
+        --dest /models/multilingual-e5-base
+RUN uv run --no-project --with "huggingface-hub>=1.10" \
+        python fetch_embedding_model.py --model bge-m3 \
+        --revision "${EMBEDDING_BGE_M3_REVISION}" \
         --dest /models/bge-m3-onnx-int8
 
 # ── Runtime image ────────────────────────────────────────────────────────
 FROM python:3.13-slim
-ARG EMBEDDING_REVISION
+ARG EMBEDDING_E5_REVISION
+ARG EMBEDDING_BGE_M3_REVISION
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
-# Model layer first: it's large (~570 MB) and rarely changes, so keeping it
-# above the frequently-churning app code means it stays cached (and isn't
-# re-pushed) until the pinned revision changes.
+# Model layer first: it's large and rarely changes, so keeping it above the
+# frequently-churning app code means it stays cached (and isn't re-pushed)
+# until a pinned revision changes. Both models are copied; the ENV below picks
+# e5-base as the default. To run BGE-M3 instead, override at deploy time:
+#   EMBEDDING_MODEL_PATH=/app/models/bge-m3-onnx-int8/model_quantized.onnx
+#   EMBEDDING_TOKENIZER_PATH=/app/models/bge-m3-onnx-int8/tokenizer.json
+#   EMBEDDING_REVISION_HASH=<the bge-m3 SHA>  EMBEDDING_MODEL_KIND=bge-m3
+#   EMBEDDING_DENSE_DIM=1024  (and unset EMBEDDING_MAX_TOKENS)
 COPY --from=model /models /app/models
-ENV EMBEDDING_MODEL_PATH=/app/models/bge-m3-onnx-int8/model_quantized.onnx \
-    EMBEDDING_TOKENIZER_PATH=/app/models/bge-m3-onnx-int8/tokenizer.json \
-    EMBEDDING_REVISION_HASH=${EMBEDDING_REVISION}
+ENV EMBEDDING_MODEL_PATH=/app/models/multilingual-e5-base/onnx/model_qint8_avx512_vnni.onnx \
+    EMBEDDING_TOKENIZER_PATH=/app/models/multilingual-e5-base/tokenizer.json \
+    EMBEDDING_REVISION_HASH=${EMBEDDING_E5_REVISION} \
+    EMBEDDING_MODEL_KIND=e5 \
+    EMBEDDING_DENSE_DIM=768 \
+    EMBEDDING_MAX_TOKENS=512
 
 COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --no-editable --no-dev --frozen

--- a/docs/adr/014-embedding-port-and-self-hosted-model.md
+++ b/docs/adr/014-embedding-port-and-self-hosted-model.md
@@ -128,9 +128,9 @@ port or `services`:
   mean-pooled): ~2–3× faster CPU encoding than BGE-M3 at a modest cross-lingual
   quality trade, which is the right default for the short multilingual feedback
   this service sees. It is the official repo's own int8 ONNX export, pinned by
-  hash and validated the same way (point 3). **BGE-M3 remains baked into the
-  image and one env override away** for deployments that prefer its stronger
-  cross-lingual quality.
+  hash and validated the same way (point 3). **BGE-M3 is no longer baked into
+  the image**: deployments that prefer its stronger cross-lingual quality add a
+  fetch step to the `Dockerfile` model stage and override the `EMBEDDING_*` env.
 
 The conversion-correctness check (point 3) now applies per artifact; the
 e2e cosine-vs-official test still covers BGE-M3 via the retained

--- a/docs/adr/014-embedding-port-and-self-hosted-model.md
+++ b/docs/adr/014-embedding-port-and-self-hosted-model.md
@@ -107,6 +107,35 @@ is a pure math graph that cannot execute code or perform I/O, unlike a pickle
 - A future externalised or self-converted model is a drop-in: a new adapter
   behind the same port, no `services` change.
 
+## Addendum (2026-06-01): configurable model family, e5-base default
+
+Embedding latency (CPU-bound encoding) is the dominant cost on the
+hierarchical path for the typical short-text corpus, so the adapter was
+generalised from BGE-M3-only to a **configurable family** without changing the
+port or `services`:
+
+- `BgeM3OnnxEmbedder` became `OnnxEmbedder` (`qfa.adapters.embedding`), still
+  explicitly inheriting `EmbeddingPort`. The only behavioural fork is output
+  handling: `pooling="pre_pooled"` (BGE-M3's already-pooled `dense_vecs`) vs
+  `pooling="mean"` (mean-pool token-level `last_hidden_state` over the
+  attention mask, for E5), plus an optional `query_prefix` (`query: ` for E5).
+  The security posture (points 4–5 above) is unchanged and written once.
+- `EMBEDDING_MODEL_KIND` selects the family; `EMBEDDING_DENSE_DIM` and
+  `EMBEDDING_MAX_TOKENS` are per-artifact knobs (so e5-base 768-d and e5-small
+  384-d share `kind=e5`). The dimension is validated per batch — a mismatched
+  artifact/config fails loud.
+- **The default model is now `intfloat/multilingual-e5-base`** (768-d,
+  mean-pooled): ~2–3× faster CPU encoding than BGE-M3 at a modest cross-lingual
+  quality trade, which is the right default for the short multilingual feedback
+  this service sees. It is the official repo's own int8 ONNX export, pinned by
+  hash and validated the same way (point 3). **BGE-M3 remains baked into the
+  image and one env override away** for deployments that prefer its stronger
+  cross-lingual quality.
+
+The conversion-correctness check (point 3) now applies per artifact; the
+e2e cosine-vs-official test still covers BGE-M3 via the retained
+`build_bge_m3_embedder` entry point.
+
 ## Participants
 
 Marius

--- a/docs/architecture/07-hierarchical-analysis.md
+++ b/docs/architecture/07-hierarchical-analysis.md
@@ -22,9 +22,14 @@ near each other. The model must be **multilingual** — humanitarian feedback
 arrives in many languages, and a monolingual model would cluster by language
 rather than theme. The model is the only external, swappable dependency in the
 path, so it sits behind {py:class}`~qfa.domain.ports.EmbeddingPort`. The choice
-of a *self-hosted BGE-M3 ONNX-int8* model over a hosted embedding API — and why
-that specific model and format — is recorded in
-[ADR-014](../adr/014-embedding-port-and-self-hosted-model.md).
+of a *self-hosted ONNX-int8* model over a hosted embedding API — and why that
+format — is recorded in
+[ADR-014](../adr/014-embedding-port-and-self-hosted-model.md). The adapter
+supports two model families, selected by `EMBEDDING_MODEL_KIND`: the default
+**multilingual-e5-base** (768-d, mean-pooled — smaller and faster) and
+**BGE-M3** (1024-d, pre-pooled — stronger cross-lingual quality), both baked
+into the image (see the
+[settings reference](../operations/settings-reference.md)).
 
 ## The pipeline
 

--- a/docs/architecture/07-hierarchical-analysis.md
+++ b/docs/architecture/07-hierarchical-analysis.md
@@ -26,10 +26,10 @@ of a *self-hosted ONNX-int8* model over a hosted embedding API — and why that
 format — is recorded in
 [ADR-014](../adr/014-embedding-port-and-self-hosted-model.md). The adapter
 supports two model families, selected by `EMBEDDING_MODEL_KIND`: the default
-**multilingual-e5-base** (768-d, mean-pooled — smaller and faster) and
-**BGE-M3** (1024-d, pre-pooled — stronger cross-lingual quality), both baked
-into the image (see the
-[settings reference](../operations/settings-reference.md)).
+**multilingual-e5-base** (768-d, mean-pooled — smaller and faster), which is
+baked into the image, and **BGE-M3** (1024-d, pre-pooled — stronger
+cross-lingual quality), which requires adding a fetch step to the image build
+(see the [settings reference](../operations/settings-reference.md)).
 
 ## The pipeline
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -48,8 +48,16 @@ slow run can be diagnosed from logs alone — no profiler attach required.
   record/chunk counts and durations.
 - **Per chunk and per LLM call, at DEBUG** — each map chunk logs a `starting map
   chunk i/N` line and a `done` line; each leaf judge logs a `starting`/`done` line
-  with its score (or `excluded` when the chunk could not be judged). The per-chunk
-  `done` lines split their duration into `queued=<s>` (time waiting for a
+  with its score (or `excluded` when the chunk could not be judged). The reduce
+  phase, which is a *recursive* tree-reduce rather than a flat fan-out, logs each
+  level with its recursion `depth=<d>` (0 at the top): a `synthesising N
+  partial(s)` line on entry, then either a single `synthesis … done` line (when the
+  partials fit one reduce call) or a split line (`N partial(s) exceed the token
+  budget -> K group(s)`) followed by a `reducing group i/K` line per group and a
+  closing `K group(s) reduced to M intermediate(s); starting final reduce` line —
+  so a multi-level synthesis shows both how deep the tree is and how much of the
+  current level remains. The per-chunk and per-reduce `done` lines split their
+  duration into `queued=<s>` (time waiting for a
   concurrency slot) and `call=<s>` (the LLM round-trip after the slot was
   acquired), so a long chunk caused by queue backlog is distinguishable from a
   genuinely slow call. Each LLM round-trip also logs `model`, `latency`,

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -39,19 +39,24 @@ slow run can be diagnosed from logs alone — no profiler attach required.
 
 - **Per phase, at INFO** — `Orchestrator.analyze_hierarchical` logs a `starting
   <phase>` line *before* each potentially slow step (embedding, clustering, map,
-  then judge+reduce) and a `<phase> … in <seconds>s` line after it, plus a closing
+  reduce, then judge) and a `<phase> … in <seconds>s` line after it, plus a closing
   one-line breakdown: `analyze_hierarchical done in 87.7s (anonymise=… embed=…
-  cluster=… map=… judge+reduce=…)`. The leaf judges and the reduce run
-  concurrently, so they are timed together as one `judge + reduce` phase. The map
-  line reports the concurrency cap (`up to N concurrent LLM call(s)`). These lines
-  carry only record/chunk counts and durations.
+  cluster=… map=… reduce=… judge=…)`. Reduce runs *before* the judges (the
+  synthesis is the deliverable and gets slot priority; the judges only feed the
+  confidence), so the two are timed separately. The map line reports the
+  concurrency cap (`up to N concurrent LLM call(s)`). These lines carry only
+  record/chunk counts and durations.
 - **Per chunk and per LLM call, at DEBUG** — each map chunk logs a `starting map
-  chunk i/N` line and a `done` line with its duration; each leaf judge logs a
-  `starting`/`done` line with its score; each LLM round-trip logs `model`,
-  `latency`, `prompt_tokens`, `completion_tokens`, and `cost` from the
-  `LiteLLMClient` adapter. DEBUG (not INFO) because hierarchical mode fans out one
-  call per chunk plus judges and reduces — at INFO this would flood the log.
-  Because map runs concurrently and judging overlaps reducing, these per-chunk
+  chunk i/N` line and a `done` line; each leaf judge logs a `starting`/`done` line
+  with its score (or `excluded` when the chunk could not be judged). The per-chunk
+  `done` lines split their duration into `queued=<s>` (time waiting for a
+  concurrency slot) and `call=<s>` (the LLM round-trip after the slot was
+  acquired), so a long chunk caused by queue backlog is distinguishable from a
+  genuinely slow call. Each LLM round-trip also logs `model`, `latency`,
+  `prompt_tokens`, `completion_tokens`, and `cost` from the `LiteLLMClient`
+  adapter, and its per-attempt timeout plus the retry budget. DEBUG (not INFO)
+  because hierarchical mode fans out one call per chunk plus judges and reduces —
+  at INFO this would flood the log. Because map runs concurrently, these per-chunk
   lines interleave.
 
 All of these are built from the safe-to-log list above; none interpolate

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -49,15 +49,11 @@ slow run can be diagnosed from logs alone — no profiler attach required.
 - **Per chunk and per LLM call, at DEBUG** — each map chunk logs a `starting map
   chunk i/N` line and a `done` line; each leaf judge logs a `starting`/`done` line
   with its score (or `excluded` when the chunk could not be judged). The reduce
-  phase, which is a *recursive* tree-reduce rather than a flat fan-out, logs each
-  level with its recursion `depth=<d>` (0 at the top): a `synthesising N
-  partial(s)` line on entry, then either a single `synthesis … done` line (when the
-  partials fit one reduce call) or a split line (`N partial(s) exceed the token
-  budget -> K group(s)`) followed by a `reducing group i/K` line per group and a
-  closing `K group(s) reduced to M intermediate(s); starting final reduce` line —
-  so a multi-level synthesis shows both how deep the tree is and how much of the
-  current level remains. The per-chunk and per-reduce `done` lines split their
-  duration into `queued=<s>` (time waiting for a
+  phase is a *recursive* tree-reduce rather than a flat fan-out; rather than log
+  every call, it emits a single line each time it has to split (`N partial(s)
+  exceed the token budget; tree-reducing in K group(s)`), so a multi-level
+  synthesis is visible without one line per group. The per-chunk `done` lines
+  split their duration into `queued=<s>` (time waiting for a
   concurrency slot) and `call=<s>` (the LLM round-trip after the slot was
   acquired), so a long chunk caused by queue backlog is distinguishable from a
   genuinely slow call. Each LLM round-trip also logs `model`, `latency`,

--- a/docs/operations/settings-reference.md
+++ b/docs/operations/settings-reference.md
@@ -12,7 +12,7 @@ Every environment variable the app reads. Settings are loaded by `pydantic-setti
 | `LLM_API_KEY` | **yes** | — | Provider API key. Stored as `SecretStr`. |
 | `LLM_API_BASE` | only some providers | `""` | E.g. `https://<resource>.openai.azure.com/` for Azure OpenAI. |
 | `LLM_API_VERSION` | only some providers | `""` | API version where the provider expects one. |
-| `LLM_TIMEOUT_SECONDS` | no | `115.0` | Per-LLM-call timeout. |
+| `LLM_TIMEOUT_SECONDS` | no | `115.0` | Per-*attempt* LLM-call timeout. A single call retries transient failures (timeout, rate-limit) up to `3×` this budget; the orchestrator sizes the per-attempt timeout against the request deadline so the worst-case retry sequence still fits. |
 | `LLM_MAX_TOTAL_TOKENS` | no | `100000` | Token budget guard. Estimated as `len(text) / LLM_CHARS_PER_TOKEN`. |
 | `LLM_CHARS_PER_TOKEN` | no | `4` | Conversion ratio used by the token budget guard. |
 

--- a/docs/operations/settings-reference.md
+++ b/docs/operations/settings-reference.md
@@ -19,12 +19,14 @@ Every environment variable the app reads. Settings are loaded by `pydantic-setti
 ## Embedding (`EMBEDDING_*`)
 
 Only consumed by `mode=hierarchical`. The path defaults to *empty* at the
-settings layer, but **the official Docker image bakes two ONNX embedders in
-(multilingual-e5-base and BGE-M3) and sets the `ENV` to the e5-base default**
-(see the builder stage in `Dockerfile`), so a deployed image serves
-hierarchical out of the box. The 502 `analysis_unavailable` response only
-applies where the model is genuinely absent — a bare local run, or a
-deployment that strips these vars.
+settings layer, but **the official Docker image bakes the default ONNX embedder
+in (multilingual-e5-base) and sets the `ENV` to it** (see the builder stage in
+`Dockerfile`), so a deployed image serves hierarchical out of the box. The 502
+`analysis_unavailable` response only applies where the model is genuinely
+absent — a bare local run, or a deployment that strips these vars. Running a
+different family (e.g. BGE-M3) in production means adding a fetch step to the
+`Dockerfile` model stage and overriding the `EMBEDDING_*` env — it is **not**
+baked in by default.
 
 Two model **families** are supported, selected by `EMBEDDING_MODEL_KIND`; the
 family fixes the adapter's output handling (pooling + query prefix) while the
@@ -36,8 +38,9 @@ dimension and token cap are per-artifact knobs (`EMBEDDING_DENSE_DIM` /
   modest cross-lingual quality trade. e5-small (384-d) is the same `kind`.
 - **`bge-m3`** (1024-d) — takes the model's already-pooled `dense_vecs` head
   as-is. The strongest cross-lingual model; select it when quality matters
-  more than latency. Baked into the image and one env override away (see the
-  `Dockerfile` comment for the exact `EMBEDDING_*` values).
+  more than latency. Not baked into the image: add a fetch step to the
+  `Dockerfile` model stage (`fetch_embedding_model.py --model bge-m3`) and
+  point the `EMBEDDING_*` env at it (see the `Dockerfile` comment).
 
 For **local development**, fetch an artifact and get the matching env lines
 with `uv run python scripts/fetch_embedding_model.py` (defaults to e5-base;

--- a/docs/operations/settings-reference.md
+++ b/docs/operations/settings-reference.md
@@ -18,22 +18,41 @@ Every environment variable the app reads. Settings are loaded by `pydantic-setti
 
 ## Embedding (`EMBEDDING_*`)
 
-Only consumed by `mode=hierarchical`. The model defaults to *empty* at the
-settings layer, but **the official Docker image bakes the BGE-M3 ONNX
-artifact in and sets all three paths as `ENV`** (see the builder stage in
-`Dockerfile`), so a deployed image serves hierarchical out of the box. The
-502 `analysis_unavailable` response only applies where the model is genuinely
-absent — a bare local run, or a deployment that strips these vars.
+Only consumed by `mode=hierarchical`. The path defaults to *empty* at the
+settings layer, but **the official Docker image bakes two ONNX embedders in
+(multilingual-e5-base and BGE-M3) and sets the `ENV` to the e5-base default**
+(see the builder stage in `Dockerfile`), so a deployed image serves
+hierarchical out of the box. The 502 `analysis_unavailable` response only
+applies where the model is genuinely absent — a bare local run, or a
+deployment that strips these vars.
 
-For **local development**, fetch the artifact and get the matching env lines
-with `uv run python scripts/fetch_embedding_model.py` (downloads to a
-gitignored `.models/` and prints the three `EMBEDDING_*` values to paste).
+Two model **families** are supported, selected by `EMBEDDING_MODEL_KIND`; the
+family fixes the adapter's output handling (pooling + query prefix) while the
+dimension and token cap are per-artifact knobs (`EMBEDDING_DENSE_DIM` /
+`EMBEDDING_MAX_TOKENS`):
+
+- **`e5`** (default, multilingual-e5-base, 768-d) — mean-pools token vectors
+  and prepends the `query: ` prefix. Smaller and faster than BGE-M3 for a
+  modest cross-lingual quality trade. e5-small (384-d) is the same `kind`.
+- **`bge-m3`** (1024-d) — takes the model's already-pooled `dense_vecs` head
+  as-is. The strongest cross-lingual model; select it when quality matters
+  more than latency. Baked into the image and one env override away (see the
+  `Dockerfile` comment for the exact `EMBEDDING_*` values).
+
+For **local development**, fetch an artifact and get the matching env lines
+with `uv run python scripts/fetch_embedding_model.py` (defaults to e5-base;
+`--model bge-m3` / `--model e5-small` for the others). It downloads to a
+gitignored `.models/` and prints every `EMBEDDING_*` value to paste, including
+`EMBEDDING_MODEL_KIND` and `EMBEDDING_DENSE_DIM`.
 
 | Variable | Required | Default | Notes |
 |---|---|---|---|
-| `EMBEDDING_MODEL_PATH` | for hierarchical | `""` (baked: `/app/models/bge-m3-onnx-int8/model_quantized.onnx`) | Path to the mirrored BGE-M3 `model_quantized.onnx`. Never a HuggingFace URL in production. |
-| `EMBEDDING_TOKENIZER_PATH` | for hierarchical | `""` (baked: `…/tokenizer.json`) | Path to the mirrored tokenizer file. Defaults to `EMBEDDING_MODEL_PATH` when empty. |
+| `EMBEDDING_MODEL_PATH` | for hierarchical | `""` (baked: `/app/models/multilingual-e5-base/onnx/model_qint8_avx512_vnni.onnx`) | Path to the mirrored ONNX graph. Never a HuggingFace URL in production. |
+| `EMBEDDING_TOKENIZER_PATH` | for hierarchical | `""` (baked: `…/multilingual-e5-base/tokenizer.json`) | Path to the mirrored tokenizer file. Defaults to `EMBEDDING_MODEL_PATH` when empty. |
 | `EMBEDDING_REVISION_HASH` | for hierarchical | `""` (baked: the pinned commit) | Pinned artifact revision/content hash. |
+| `EMBEDDING_MODEL_KIND` | no | `e5` | Model family: `e5` (mean-pool + `query: ` prefix) or `bge-m3` (pre-pooled). Selects how the ONNX output becomes a vector. |
+| `EMBEDDING_DENSE_DIM` | no | `768` | Expected output dimensionality, validated per batch so a mismatched artifact/config fails loud. e5-base 768; e5-small 384; BGE-M3 1024. |
+| `EMBEDDING_MAX_TOKENS` | no | family default | Tokenizer truncation cap. Unset → the family's natural context (8192 for `bge-m3`, 512 for `e5`). Set lower to bound the per-record (and, since padding is per-batch, per-batch) cost from long outliers. |
 | `EMBEDDING_INTRA_OP_NUM_THREADS` | no | core count | onnxruntime intra-op threads for the batched encode. |
 | `EMBEDDING_BATCH_SIZE` | no | `100` | Records encoded per onnxruntime batch. The corpus is embedded in sequential batches of this size to bound peak memory on large inputs (padding is per-batch). Lower it if the embedder is memory-pressured; raise it for throughput on roomy hosts. |
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ people ask about most: regenerating the `analyze_corpus.yaml` fixture.
 
 | Script                          | What it does                                                     |
 | ------------------------------- | ---------------------------------------------------------------- |
-| `fetch_embedding_model.py`      | Download the BGE-M3 ONNX embedder to a gitignored local path (dev). |
+| `fetch_embedding_model.py`      | Download an ONNX embedder (`--model` e5-base/e5-small/bge-m3; default e5-base) to a gitignored local path (dev). |
 | `generate_corpus.py`            | Build / regenerate `fixtures/analyze_corpus.yaml` (see below).   |
 | `generate_corpus.prompt.md`     | LLM prompt that fills in `text` during corpus generation.        |
 | `stress_analyze.py`             | Drive `POST /v1/analyze` with a seeded corpus sample, single-call or in parallel (see below). |

--- a/scripts/fetch_embedding_model.py
+++ b/scripts/fetch_embedding_model.py
@@ -1,18 +1,28 @@
-r"""Download the self-hosted BGE-M3 ONNX-int8 embedding model for local dev.
+r"""Download a self-hosted ONNX embedding model for local dev.
 
 Helper script (run manually, not in CI). Hierarchical analysis
 (``mode=hierarchical`` on ``POST /v1/analyze``, and the in-process calls
-the ``notebooks/analyze_corpus.ipynb`` notebook makes) needs a local
-BGE-M3 ONNX export wired up via three env vars — ``EMBEDDING_MODEL_PATH``,
-``EMBEDDING_TOKENIZER_PATH``, ``EMBEDDING_REVISION_HASH``. Without them the
-orchestrator carries ``_embedder is None`` and the hierarchical path raises
-``no embedder configured``.
+the ``notebooks/analyze_corpus.ipynb`` notebook makes) needs a local ONNX
+embedding artifact wired up via env vars. Without them the orchestrator
+carries ``_embedder is None`` and the hierarchical path raises ``no
+embedder configured``.
 
 This script fetches the two files the adapter actually loads
-(:func:`qfa.adapters.embedding.build_bge_m3_embedder` opens the quantized
-ONNX graph + the fast-tokenizer JSON; the rest of the HF repo is unused at
-runtime), drops them in a gitignored default location under the repo, and
-prints the three ``.env`` lines to paste.
+(:func:`qfa.adapters.embedding.build_onnx_embedder` opens the ONNX graph +
+the fast-tokenizer JSON; the rest of the HF repo is unused at runtime),
+drops them in a gitignored default location under the repo, and prints the
+``.env`` lines to paste — including ``EMBEDDING_MODEL_KIND`` and
+``EMBEDDING_DENSE_DIM`` so the adapter handles the model's output correctly.
+
+Supported models (``--model``):
+
+* ``e5-base`` (default) — intfloat/multilingual-e5-base, 768-d, mean-pooled.
+  The default model: smaller and faster than BGE-M3 for a modest
+  cross-lingual quality trade.
+* ``e5-small`` — intfloat/multilingual-e5-small, 384-d, mean-pooled. Smallest
+  and fastest; the largest quality trade.
+* ``bge-m3`` — BAAI BGE-M3, 1024-d, pre-pooled dense head. The strongest
+  cross-lingual model; select it when quality matters more than latency.
 
 **Dev-only — not the production path.** Per ADR-014 production never
 fetches from HuggingFace at runtime: the artifact is mirrored to an
@@ -28,7 +38,8 @@ file). We only need two files, so the serial path costs nothing.
 
 Run::
 
-    uv run python scripts/fetch_embedding_model.py
+    uv run python scripts/fetch_embedding_model.py                 # e5-base
+    uv run python scripts/fetch_embedding_model.py --model bge-m3
 
 Then copy the printed ``EMBEDDING_*`` lines into your ``.env`` (or export
 them) and restart any running server / Jupyter kernel.
@@ -40,6 +51,7 @@ import argparse
 import logging
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger("fetch_embedding_model")
@@ -47,28 +59,88 @@ logger = logging.getLogger("fetch_embedding_model")
 # The script lives at ``scripts/`` so the repo root is one level up.
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-# Community pre-built ONNX-int8 export of ``BAAI/bge-m3`` (see ADR-014). We
-# pin a specific commit so the download is reproducible and its content
-# matches the EMBEDDING_REVISION_HASH printed below; bump deliberately.
-# DEFAULT_REVISION is the tip of the repo's ``main`` as of 2026-05-29,
-# resolved to its commit SHA (``main`` is a moving ref). Keep this in sync
-# with the ARG EMBEDDING_REVISION default in the Dockerfile.
-DEFAULT_REPO_ID = "gpahal/bge-m3-onnx-int8"
-DEFAULT_REVISION = "2b34e84df040034d4b9eabb62383a87c18955822"
 
-# The two files the runtime adapter loads. NOTE: the ONNX graph in this repo
-# is ``model_quantized.onnx`` (optimum's ``<name>_quantized.onnx`` naming),
-# *not* ``model.onnx`` — an allow-pattern mismatch here downloads nothing.
-ONNX_FILENAME = "model_quantized.onnx"
-TOKENIZER_FILENAME = "tokenizer.json"
+@dataclass(frozen=True)
+class ModelSpec:
+    """A downloadable embedding artifact and the config it implies.
 
-# Gitignored default location, kept under the repo so the paths are easy to
-# find and reason about. Mirrors the ``.models/bge-m3-onnx-int8`` default
-# documented in ``.env.example``.
-DEFAULT_DEST = REPO_ROOT / ".models" / "bge-m3-onnx-int8"
+    ``onnx_relpath``/``tokenizer_relpath`` are paths *within* the HF repo
+    (BGE-M3 ships the graph at the repo root; the E5 repos nest it under
+    ``onnx/``). ``model_kind``/``dense_dim``/``max_tokens`` are the
+    ``EMBEDDING_*`` values that make the adapter handle this model correctly:
+    the family selects pooling + query prefix, the dimension is validated per
+    batch, and ``max_tokens`` (``None`` = the family's natural context) caps
+    truncation.
+    """
+
+    key: str
+    repo_id: str
+    revision: str
+    dest_dirname: str
+    onnx_relpath: str
+    tokenizer_relpath: str
+    model_kind: str
+    dense_dim: int
+    max_tokens: int | None
 
 
-def fetch(*, repo_id: str, revision: str, dest: Path) -> tuple[Path, Path, str]:
+# Revisions are pinned to a concrete commit SHA (HF ``main`` is a moving ref)
+# so a download is reproducible and its content matches the printed
+# EMBEDDING_REVISION_HASH. To bump one: pick a newer commit, re-validate, and
+# update here (keep entries in sync with the Dockerfile's ARGs).
+MODELS: dict[str, ModelSpec] = {
+    "e5-base": ModelSpec(
+        key="e5-base",
+        # Official repo ships its own ONNX exports, including an int8 build —
+        # better provenance than a third-party conversion, matching canonical
+        # weights for the cosine-validation story.
+        repo_id="intfloat/multilingual-e5-base",
+        revision="d128750597153bb5987e10b1c3493a34e5a4502a",
+        dest_dirname="multilingual-e5-base",
+        onnx_relpath="onnx/model_qint8_avx512_vnni.onnx",
+        tokenizer_relpath="tokenizer.json",
+        model_kind="e5",
+        dense_dim=768,
+        max_tokens=512,
+    ),
+    "e5-small": ModelSpec(
+        key="e5-small",
+        repo_id="intfloat/multilingual-e5-small",
+        revision="614241f622f53c4eeff9890bdc4f31cfecc418b3",
+        dest_dirname="multilingual-e5-small",
+        onnx_relpath="onnx/model_qint8_avx512_vnni.onnx",
+        tokenizer_relpath="tokenizer.json",
+        model_kind="e5",
+        dense_dim=384,
+        max_tokens=512,
+    ),
+    "bge-m3": ModelSpec(
+        key="bge-m3",
+        # Community pre-built ONNX-int8 export of ``BAAI/bge-m3`` (see ADR-014).
+        repo_id="gpahal/bge-m3-onnx-int8",
+        revision="2b34e84df040034d4b9eabb62383a87c18955822",
+        dest_dirname="bge-m3-onnx-int8",
+        # NOTE: optimum names the quantized graph ``<name>_quantized.onnx``,
+        # *not* ``model.onnx`` — a relpath mismatch here downloads nothing.
+        onnx_relpath="model_quantized.onnx",
+        tokenizer_relpath="tokenizer.json",
+        model_kind="bge-m3",
+        dense_dim=1024,
+        max_tokens=None,
+    ),
+}
+
+DEFAULT_MODEL = "e5-base"
+
+
+def fetch(
+    *,
+    repo_id: str,
+    revision: str,
+    onnx_relpath: str,
+    tokenizer_relpath: str,
+    dest: Path,
+) -> tuple[Path, Path, str]:
     """Download the ONNX graph + tokenizer into ``dest``, serially.
 
     Resolves ``revision`` to a concrete commit SHA (so a branch name like
@@ -78,11 +150,15 @@ def fetch(*, repo_id: str, revision: str, dest: Path) -> tuple[Path, Path, str]:
     Parameters
     ----------
     repo_id : str
-        HuggingFace repo, e.g. ``gpahal/bge-m3-onnx-int8``.
+        HuggingFace repo, e.g. ``intfloat/multilingual-e5-base``.
     revision : str
         Commit SHA, tag, or branch. Resolved to a SHA for the returned hash.
+    onnx_relpath, tokenizer_relpath : str
+        Paths to the two files *within* the repo (the E5 repos nest the graph
+        under ``onnx/``; BGE-M3 ships it at the root).
     dest : Path
-        Target directory; created if absent.
+        Target directory; created if absent. Repo structure is preserved
+        beneath it, so a nested ``onnx_relpath`` lands at ``dest/onnx/...``.
 
     Returns
     -------
@@ -108,18 +184,22 @@ def fetch(*, repo_id: str, revision: str, dest: Path) -> tuple[Path, Path, str]:
     logger.info("Resolved %s@%s -> %s", repo_id, revision, resolved_sha)
 
     dest.mkdir(parents=True, exist_ok=True)
-    logger.info("Downloading %s + %s (serial)", ONNX_FILENAME, TOKENIZER_FILENAME)
+    logger.info("Downloading %s + %s (serial)", onnx_relpath, tokenizer_relpath)
     snapshot_download(
         repo_id=repo_id,
         revision=resolved_sha,
-        allow_patterns=[ONNX_FILENAME, TOKENIZER_FILENAME],
+        allow_patterns=[onnx_relpath, tokenizer_relpath],
         local_dir=str(dest),
         max_workers=1,  # serialize file downloads — avoid HF 429 rate limits
     )
 
-    model_path = dest / ONNX_FILENAME
-    tokenizer_path = dest / TOKENIZER_FILENAME
-    missing = [p.name for p in (model_path, tokenizer_path) if not p.is_file()]
+    model_path = dest / onnx_relpath
+    tokenizer_path = dest / tokenizer_relpath
+    missing = [
+        rel
+        for rel, p in ((onnx_relpath, model_path), (tokenizer_relpath, tokenizer_path))
+        if not p.is_file()
+    ]
     if missing:
         raise RuntimeError(
             f"download finished but expected files are missing: {missing} "
@@ -129,33 +209,44 @@ def fetch(*, repo_id: str, revision: str, dest: Path) -> tuple[Path, Path, str]:
 
 
 def main() -> int:
-    """Parse args, download the model, and print the ``.env`` lines."""
+    """Parse args, download the chosen model, and print the ``.env`` lines."""
     parser = argparse.ArgumentParser(
-        description="Download the dev BGE-M3 ONNX embedding model from HuggingFace.",
+        description="Download a dev ONNX embedding model from HuggingFace.",
+    )
+    parser.add_argument(
+        "--model",
+        choices=sorted(MODELS),
+        default=DEFAULT_MODEL,
+        help=f"Which model family/size to fetch (default: {DEFAULT_MODEL}).",
     )
     parser.add_argument(
         "--dest",
         type=Path,
-        default=DEFAULT_DEST,
-        help=f"Target directory (default: {DEFAULT_DEST}).",
+        default=None,
+        help="Target directory (default: .models/<model> under the repo).",
     )
     parser.add_argument(
         "--repo-id",
-        default=DEFAULT_REPO_ID,
-        help=f"HuggingFace repo id (default: {DEFAULT_REPO_ID}).",
+        default=None,
+        help="Override the HuggingFace repo id (default: the model's pinned repo).",
     )
     parser.add_argument(
         "--revision",
-        default=DEFAULT_REVISION,
-        help="Commit SHA, tag, or branch to pin (default: the vetted commit).",
+        default=None,
+        help="Commit SHA, tag, or branch to pin (default: the model's vetted commit).",
     )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
-    dest = args.dest.resolve()
+    spec = MODELS[args.model]
+    dest = (args.dest or (REPO_ROOT / ".models" / spec.dest_dirname)).resolve()
     model_path, tokenizer_path, sha = fetch(
-        repo_id=args.repo_id, revision=args.revision, dest=dest
+        repo_id=args.repo_id or spec.repo_id,
+        revision=args.revision or spec.revision,
+        onnx_relpath=spec.onnx_relpath,
+        tokenizer_relpath=spec.tokenizer_relpath,
+        dest=dest,
     )
 
     print()
@@ -165,6 +256,10 @@ def main() -> int:
     print(f"EMBEDDING_MODEL_PATH={model_path}")
     print(f"EMBEDDING_TOKENIZER_PATH={tokenizer_path}")
     print(f"EMBEDDING_REVISION_HASH={sha}")
+    print(f"EMBEDDING_MODEL_KIND={spec.model_kind}")
+    print(f"EMBEDDING_DENSE_DIM={spec.dense_dim}")
+    if spec.max_tokens is not None:
+        print(f"EMBEDDING_MAX_TOKENS={spec.max_tokens}")
     return 0
 
 

--- a/src/qfa/adapters/embedding.py
+++ b/src/qfa/adapters/embedding.py
@@ -1,7 +1,22 @@
-"""Self-hosted BGE-M3 ONNX-int8 embedding adapter.
+"""Self-hosted ONNX embedding adapter (multilingual, dense-only).
 
-Runs BGE-M3 (multilingual, dense-1024-d only) via ``onnxruntime``,
+Runs a multilingual sentence-embedding model via ``onnxruntime``,
 in-process, loaded once. Behind :class:`~qfa.domain.ports.EmbeddingPort`.
+
+Two model *families* are supported; they differ only in how the ONNX
+graph's output is turned into one dense vector per text:
+
+* ``bge-m3`` — the shipped BGE-M3 build emits an already-pooled
+  ``dense_vecs`` head (shape ``(batch, dim)``); the adapter takes it as-is
+  (``pooling="pre_pooled"``).
+* ``e5`` — multilingual-E5 ONNX exports emit token-level
+  ``last_hidden_state`` (shape ``(batch, seq, hidden)``); the adapter
+  **mean-pools** it over the attention mask (``pooling="mean"``) and
+  prepends the ``query: `` prefix every E5 input requires.
+
+The *dimension* and *token cap* are per-artifact, not per-family, so they
+are separate knobs (``dense_dim`` / the builder's ``max_tokens``): both
+e5-base (768-d) and e5-small (384-d) use ``model_kind="e5"``.
 
 Security posture (asserted at construction, per the design spec):
 
@@ -14,7 +29,7 @@ Security posture (asserted at construction, per the design spec):
 
 The residual attack surface is onnxruntime parser CVEs (keep patched)
 and conversion correctness (the one-time cosine~0.999 validation against
-official ``BAAI/bge-m3``, see the e2e-marked test).
+the official reference, see the e2e-marked test).
 
 Batching & concurrency: records are embedded in sequential batches of
 ``batch_size`` (default 100) — one ``session.run()`` per batch — so a large
@@ -33,16 +48,44 @@ from qfa.domain.ports import EmbeddingPort
 
 logger = logging.getLogger(__name__)
 
-_DENSE_DIM = 1024
+# Valid output-pooling strategies, see the module docstring.
+_PRE_POOLED = "pre_pooled"
+_MEAN = "mean"
+_POOLINGS = (_PRE_POOLED, _MEAN)
 
-# BGE-M3 accepts up to 8192 tokens; longer inputs are truncated. Feedback
-# records are short, so this almost never bites — it's a guardrail against a
-# pathological outlier blowing up the ONNX run.
-_MAX_TOKENS = 8192
+# Natural context windows per family. BGE-M3 accepts up to 8192 tokens; the
+# E5 family inherits its XLM-R/MiniLM backbone's 512 positional limit. Longer
+# inputs are truncated. Feedback records are short, so the cap almost never
+# bites — it is a guardrail against a pathological outlier blowing up the run
+# (and, since padding is per-batch, blowing up its whole batch's tensor).
+_BGE_M3_MAX_TOKENS = 8192
+_E5_MAX_TOKENS = 512
+
+# model_kind -> (pooling, query_prefix, default_max_tokens). The family fixes
+# the output handling; dimension and an explicit token cap are passed in.
+_FAMILY: dict[str, tuple[str, str, int]] = {
+    "bge-m3": (_PRE_POOLED, "", _BGE_M3_MAX_TOKENS),
+    "e5": (_MEAN, "query: ", _E5_MAX_TOKENS),
+}
 
 
-class BgeM3OnnxEmbedder(EmbeddingPort):
-    """BGE-M3 ONNX-int8 dense-only embedder (explicitly inherits the port)."""
+def _mean_pool(last_hidden: np.ndarray, attention_mask: np.ndarray) -> np.ndarray:
+    """Masked mean of token vectors over the sequence axis.
+
+    ``last_hidden`` is ``(batch, seq, hidden)`` and ``attention_mask`` is
+    ``(batch, seq)``; returns ``(batch, hidden)``. Pad positions (mask 0) are
+    excluded from both the sum and the divisor, so padding to the batch's
+    longest row does not perturb the result. The divisor is floored at a tiny
+    epsilon so an all-pad row (no real tokens) cannot divide by zero.
+    """
+    mask = attention_mask[:, :, None].astype(np.float32)  # (batch, seq, 1)
+    summed = (last_hidden * mask).sum(axis=1)  # (batch, hidden)
+    counts = np.clip(mask.sum(axis=1), a_min=1e-9, a_max=None)  # (batch, 1)
+    return summed / counts
+
+
+class OnnxEmbedder(EmbeddingPort):
+    """Self-hosted ONNX dense-only embedder (explicitly inherits the port)."""
 
     def __init__(
         self,
@@ -51,6 +94,9 @@ class BgeM3OnnxEmbedder(EmbeddingPort):
         revision_hash: str,
         session: Any,
         tokenizer: Any,
+        pooling: str = _PRE_POOLED,
+        query_prefix: str = "",
+        dense_dim: int = 1024,
         trust_remote_code: bool = False,
         custom_op_libraries: tuple[str, ...] = (),
         intra_op_num_threads: int | None = None,
@@ -71,6 +117,16 @@ class BgeM3OnnxEmbedder(EmbeddingPort):
         tokenizer : Any
             A callable tokenizer returning ``{"input_ids", "attention_mask"}``
             arrays. Injected for the same reason.
+        pooling : str
+            ``"pre_pooled"`` (take ``outputs[0]`` as the dense vector, BGE-M3)
+            or ``"mean"`` (mean-pool token-level ``last_hidden_state`` over the
+            attention mask, E5). Any other value raises.
+        query_prefix : str
+            String prepended to every text before tokenizing (``"query: "``
+            for E5; empty for BGE-M3).
+        dense_dim : int
+            Expected output dimensionality; each batch is validated against it
+            so a wrong artifact/config fails loud.
         trust_remote_code : bool
             MUST be ``False``. Any other value raises.
         custom_op_libraries : tuple[str, ...]
@@ -85,16 +141,18 @@ class BgeM3OnnxEmbedder(EmbeddingPort):
         Raises
         ------
         ValueError
-            If a security flag is violated, ``revision_hash`` is empty, or
-            ``batch_size`` is less than 1.
+            If a security flag is violated, ``pooling`` is unknown,
+            ``revision_hash`` is empty, or ``batch_size`` is less than 1.
         """
         if trust_remote_code:
-            raise ValueError("trust_remote_code must be False for BgeM3OnnxEmbedder")
+            raise ValueError("trust_remote_code must be False for OnnxEmbedder")
         if custom_op_libraries:
             raise ValueError(
                 "no custom-operator libraries may be registered: "
                 f"{custom_op_libraries!r}"
             )
+        if pooling not in _POOLINGS:
+            raise ValueError(f"pooling must be one of {_POOLINGS}, got {pooling!r}")
         if not revision_hash:
             raise ValueError("revision_hash must be a non-empty pinned hash")
         if batch_size < 1:
@@ -104,25 +162,31 @@ class BgeM3OnnxEmbedder(EmbeddingPort):
         self._revision_hash = revision_hash
         self._session = session
         self._tokenizer = tokenizer
+        self._pooling = pooling
+        self._query_prefix = query_prefix
+        self._dense_dim = dense_dim
         self._intra_op_num_threads = intra_op_num_threads
         self._batch_size = batch_size
         logger.info(
-            "BgeM3OnnxEmbedder ready: path=%s revision=%s threads=%s batch_size=%s",
+            "OnnxEmbedder ready: path=%s revision=%s pooling=%s dim=%d"
+            " threads=%s batch_size=%s",
             model_path,
             revision_hash,
+            pooling,
+            dense_dim,
             intra_op_num_threads,
             batch_size,
         )
 
     def embed(self, texts: tuple[str, ...]) -> tuple[tuple[float, ...], ...]:
-        """Return one dense 1024-d vector per input text, in input order.
+        """Return one dense ``dense_dim``-d vector per input text, in input order.
 
         Encodes the input in sequential batches of ``batch_size`` (one
         ``session.run`` per batch) and concatenates the results, so a large
         corpus never holds one giant padded-token tensor or activation map in
-        memory at once. Within a batch the shipped BGE-M3 ONNX build emits its
-        already-pooled ``dense_vecs`` head — shape ``(batch, 1024)`` — so there
-        is no token-dimension pooling to do here. Empty input returns ``()``
+        memory at once. Each text is prefixed with ``query_prefix`` (empty for
+        BGE-M3) before tokenizing, and the model output is reduced to one
+        vector per row according to ``pooling``. Empty input returns ``()``
         without touching the model.
         """
         if not texts:
@@ -144,62 +208,98 @@ class BgeM3OnnxEmbedder(EmbeddingPort):
     def _embed_batch(self, batch: tuple[str, ...]) -> tuple[tuple[float, ...], ...]:
         """Embed one ``<= batch_size`` slice in a single ``session.run`` call.
 
-        L2 normalises each row of the model's first output (``dense_vecs``).
-        Padding is to the longest row *in this batch*, which is why batching
-        bounds memory rather than just call count.
+        Prepends ``query_prefix`` to each text, runs the model, reduces the
+        output to one vector per row (``pre_pooled`` takes ``outputs[0]``
+        as-is; ``mean`` mean-pools the token-level ``last_hidden_state`` over
+        the attention mask), then L2-normalises each row. Padding is to the
+        longest row *in this batch*, which is why batching bounds memory rather
+        than just call count.
         """
-        encoded = self._tokenizer(list(batch))
+        prepared = (
+            [self._query_prefix + text for text in batch]
+            if self._query_prefix
+            else list(batch)
+        )
+        encoded = self._tokenizer(prepared)
         input_ids = np.asarray(encoded["input_ids"])
         attention_mask = np.asarray(encoded["attention_mask"])
 
         outputs = self._session.run(
             None, {"input_ids": input_ids, "attention_mask": attention_mask}
         )
-        # First output is dense_vecs: a pooled (batch, 1024) dense vector.
-        dense = np.asarray(outputs[0], dtype=np.float32)
+        raw = np.asarray(outputs[0], dtype=np.float32)
+        # BGE-M3's first output is already a pooled (batch, dim) dense vector;
+        # E5's is token-level (batch, seq, hidden) and must be mean-pooled.
+        dense = raw if self._pooling == _PRE_POOLED else _mean_pool(raw, attention_mask)
 
-        # L2 normalise each row (idempotent when the export already normalised).
+        # L2 normalise each row (idempotent when the export already normalised);
+        # cosine similarity over unit vectors is what clustering consumes.
         norms = np.linalg.norm(dense, axis=1, keepdims=True)
         norms = np.clip(norms, a_min=1e-12, a_max=None)
         dense = dense / norms
 
-        if dense.shape[1] != _DENSE_DIM:
+        if dense.shape[1] != self._dense_dim:
             raise ValueError(
-                f"expected {_DENSE_DIM}-d dense vectors, got {dense.shape[1]}"
+                f"expected {self._dense_dim}-d dense vectors, got {dense.shape[1]}"
             )
         return tuple(tuple(float(x) for x in row) for row in dense)
 
 
-def build_bge_m3_embedder(
+def build_onnx_embedder(
     *,
+    model_kind: str,
     model_path: str,
     tokenizer_path: str,
     revision_hash: str,
+    dense_dim: int,
+    max_tokens: int | None = None,
     intra_op_num_threads: int | None = None,
     batch_size: int = 100,
-) -> BgeM3OnnxEmbedder:
-    """Build a :class:`BgeM3OnnxEmbedder` from the mirrored local artifact.
+) -> OnnxEmbedder:
+    """Build an :class:`OnnxEmbedder` for a model family from a local artifact.
 
-    Loads the ONNX session with the standard CPU provider and the
-    configured thread count, and loads the tokenizer from the mirrored
-    files. Imports of ``onnxruntime``/``tokenizers`` are local to this
-    function so unit tests (which inject fakes) never trigger them.
+    Resolves ``model_kind`` to its pooling strategy, query prefix, and natural
+    token cap, loads the ONNX session with the standard CPU provider and the
+    configured thread count, and loads the tokenizer from the mirrored files.
+    Imports of ``onnxruntime``/``tokenizers`` are local to this function so
+    unit tests (which inject fakes) never trigger them.
 
     Parameters
     ----------
+    model_kind : str
+        ``"bge-m3"`` or ``"e5"`` — selects pooling + query prefix + the default
+        token cap (see :data:`_FAMILY`).
     model_path : str
-        Path to the mirrored ``model.onnx``.
+        Path to the mirrored ONNX graph.
     tokenizer_path : str
-        Path to the mirrored tokenizer directory/file.
+        Path to the mirrored tokenizer file.
     revision_hash : str
         Pinned artifact hash (passed through to the constructor's check).
+    dense_dim : int
+        Expected output dimensionality, validated per batch.
+    max_tokens : int | None
+        Tokenizer truncation cap; ``None`` uses the family's natural context
+        (8192 for ``bge-m3``, 512 for ``e5``).
     intra_op_num_threads : int | None
         onnxruntime intra-op thread count; ``None`` keeps the core-count
         default.
     batch_size : int
         Records encoded per ``session.run`` call (memory bound for large
         corpora); passed through to the constructor.
+
+    Raises
+    ------
+    ValueError
+        If ``model_kind`` is not a known family.
     """
+    try:
+        pooling, query_prefix, default_max_tokens = _FAMILY[model_kind]
+    except KeyError:
+        raise ValueError(
+            f"unknown model_kind {model_kind!r}; expected one of {sorted(_FAMILY)}"
+        ) from None
+    effective_max_tokens = max_tokens if max_tokens is not None else default_max_tokens
+
     import onnxruntime as ort
     from tokenizers import Tokenizer
 
@@ -218,15 +318,15 @@ def build_bge_m3_embedder(
     # disabled, so ``encode_batch`` returns ragged sequences and the
     # ``np.array([...])`` below raises on any batch of differing-length
     # texts. Enable both explicitly: dynamic padding to the batch's longest
-    # row (no fixed waste) and truncation at the model's context limit.
-    # Mean-pooling already masks the pad positions via ``attention_mask``,
-    # so the pad token id does not affect the output vectors — we still set
-    # the model's real pad token when present for correctness.
+    # row (no fixed waste) and truncation at the family's context limit.
+    # Pooling masks the pad positions via ``attention_mask``, so the pad token
+    # id does not affect the output vectors — we still set the model's real
+    # pad token when present for correctness.
     pad_id = hf_tokenizer.token_to_id("<pad>")
     if pad_id is None:
         pad_id = 0
     pad_token = hf_tokenizer.id_to_token(pad_id) or "<pad>"
-    hf_tokenizer.enable_truncation(max_length=_MAX_TOKENS)
+    hf_tokenizer.enable_truncation(max_length=effective_max_tokens)
     hf_tokenizer.enable_padding(pad_id=pad_id, pad_token=pad_token)
 
     def _tokenize(batch: list[str]) -> dict[str, "np.ndarray"]:
@@ -235,13 +335,42 @@ def build_bge_m3_embedder(
         attention_mask = np.array([e.attention_mask for e in encodings])
         return {"input_ids": input_ids, "attention_mask": attention_mask}
 
-    return BgeM3OnnxEmbedder(
+    return OnnxEmbedder(
         model_path=model_path,
         revision_hash=revision_hash,
         session=session,
         tokenizer=_tokenize,
+        pooling=pooling,
+        query_prefix=query_prefix,
+        dense_dim=dense_dim,
         trust_remote_code=False,
         custom_op_libraries=(),
+        intra_op_num_threads=intra_op_num_threads,
+        batch_size=batch_size,
+    )
+
+
+def build_bge_m3_embedder(
+    *,
+    model_path: str,
+    tokenizer_path: str,
+    revision_hash: str,
+    intra_op_num_threads: int | None = None,
+    batch_size: int = 100,
+) -> OnnxEmbedder:
+    """Build the BGE-M3 (1024-d, pre-pooled) embedder — a thin family wrapper.
+
+    Kept as the named entry point for the BGE-M3 path (used by the e2e
+    artifact-validation test); delegates to :func:`build_onnx_embedder` with
+    ``model_kind="bge-m3"`` and the model's 1024-d / 8192-token defaults.
+    """
+    return build_onnx_embedder(
+        model_kind="bge-m3",
+        model_path=model_path,
+        tokenizer_path=tokenizer_path,
+        revision_hash=revision_hash,
+        dense_dim=1024,
+        max_tokens=None,
         intra_op_num_threads=intra_op_num_threads,
         batch_size=batch_size,
     )

--- a/src/qfa/adapters/llm_client.py
+++ b/src/qfa/adapters/llm_client.py
@@ -9,9 +9,9 @@ from litellm.exceptions import APIError, BadRequestError, RateLimitError, Timeou
 from litellm.utils import type_to_response_format_param
 from pydantic import BaseModel, ValidationError
 from tenacity import (
+    AsyncRetrying,
     after_log,
     before_sleep_log,
-    retry,
     retry_if_exception_type,
     stop_after_delay,
     wait_exponential,
@@ -27,6 +27,7 @@ from qfa.domain.errors import (
 )
 from qfa.domain.models import LLMResponse, T_Response
 from qfa.domain.ports import LLMPort
+from qfa.settings import LLM_RETRY_BUDGET_MULTIPLIER
 from qfa.utils import timed
 
 logger = logging.getLogger(__name__)
@@ -183,13 +184,56 @@ class LiteLLMClient(LLMPort):
                 limit=self._max_total_tokens,
             )
 
-    @retry(
-        wait=wait_exponential(multiplier=1, max=10),
-        stop=stop_after_delay(60),
-        retry=retry_if_exception_type((LLMTimeoutError, LLMRateLimitError)),
-        before_sleep=before_sleep_log(logger, logging.DEBUG),
-        after=after_log(logger, logging.DEBUG),
-    )
+    async def _complete_once(
+        self,
+        *,
+        system_message: str,
+        user_message: str,
+        tenant_id: str,
+        timeout: float,
+        response_format: dict | None,
+    ):
+        """Issue a single provider completion, translating provider errors.
+
+        This is exactly one ``acompletion`` round-trip plus the boundary
+        translation from litellm exceptions to ``qfa.domain.errors``. It does
+        NOT retry, check the token limit, scan for injection, or parse the
+        response — :meth:`complete` owns those (they must run once, not once
+        per attempt). Factored out so the retry loop wraps only the network
+        call, and so the error-mapping contract can be unit-tested on a single
+        attempt without driving the retry loop.
+        """
+        try:
+            return await acompletion(
+                model=self._model,
+                messages=[
+                    {"role": "system", "content": system_message},
+                    {"role": "user", "content": user_message},
+                ],
+                api_key=self._api_key,
+                api_base=self._api_base or None,
+                api_version=self._api_version or None,
+                user=tenant_id,
+                timeout=timeout,
+                response_format=response_format,
+            )
+        except Timeout as exc:
+            logger.error(exc)
+            raise LLMTimeoutError(str(exc)) from exc
+        except RateLimitError as exc:
+            logger.error(exc)
+            raise LLMRateLimitError(str(exc)) from exc
+        except BadRequestError as exc:
+            logger.error(exc)
+            msg = str(exc)
+            if "filtered" in msg and "content management policy" in msg:
+                raise LLMContentPolicyViolationError(str(exc)) from exc
+            else:
+                raise LLMBadRequestError(str(exc)) from exc
+        except APIError as exc:
+            logger.error(exc)
+            raise LLMError(str(exc)) from exc
+
     async def complete(
         self,
         system_message: str,
@@ -198,7 +242,16 @@ class LiteLLMClient(LLMPort):
         response_model: type[T_Response],
         timeout: float = 20.0,
     ) -> LLMResponse[T_Response]:
-        """Send a completion request via LiteLLM.
+        """Send a completion request via LiteLLM, retrying transient failures.
+
+        ``timeout`` is the budget for a *single* attempt. Transient failures
+        (timeout, rate-limit) are retried with exponential backoff up to a total
+        wall-clock budget of ``LLM_RETRY_BUDGET_MULTIPLIER * timeout``; the retry
+        wraps only the provider call, so injection/token checks and response
+        parsing happen exactly once. Callers that enforce a deadline must size
+        ``timeout`` so this worst-case budget still fits (the orchestrator does
+        this in ``_check_deadline_and_get_timeout``). Bad-request and generic
+        API errors are not retried — they are not transient.
 
         Parameters
         ----------
@@ -207,7 +260,7 @@ class LiteLLMClient(LLMPort):
         user_message : str
             The user-level message to complete.
         timeout : float
-            Maximum time in seconds to wait for a response.
+            Maximum time in seconds to wait for a single attempt.
         tenant_id : str
             Tenant identifier passed as ``user`` for audit trail.
 
@@ -219,9 +272,9 @@ class LiteLLMClient(LLMPort):
         Raises
         ------
         LLMTimeoutError
-            When the provider does not respond in time.
+            When the provider does not respond in time on every attempt.
         LLMRateLimitError
-            When the provider returns a rate-limit response.
+            When the provider rate-limits on every attempt.
         LLMError
             For any other provider error or empty response.
         """
@@ -229,44 +282,39 @@ class LiteLLMClient(LLMPort):
 
         self._check_token_limit(system_message, user_message)
 
-        logger.debug(
-            "LiteLLMClient: dispatching message with timeout %.1f seconds", timeout
+        response_format = (
+            _provider_safe_response_format(response_model)
+            if issubclass(response_model, BaseModel)
+            else None
         )
+
+        retry_budget = LLM_RETRY_BUDGET_MULTIPLIER * timeout
+        logger.debug(
+            "LiteLLMClient: dispatching message with per-attempt timeout %.1fs "
+            "(retry budget %.1fs)",
+            timeout,
+            retry_budget,
+        )
+        # Retry only the provider round-trip, and only for transient errors.
+        # ``reraise=True`` surfaces the underlying domain error (not a
+        # tenacity ``RetryError``) once the budget is spent.
         with timed() as call_sw:
-            try:
-                response = await acompletion(
-                    model=self._model,
-                    messages=[
-                        {"role": "system", "content": system_message},
-                        {"role": "user", "content": user_message},
-                    ],
-                    api_key=self._api_key,
-                    api_base=self._api_base or None,
-                    api_version=self._api_version or None,
-                    user=tenant_id,
-                    timeout=timeout,
-                    response_format=_provider_safe_response_format(response_model)
-                    if issubclass(response_model, BaseModel)
-                    else None,
-                )
-            except Timeout as exc:
-                # TODO retry
-                logger.error(exc)
-                raise LLMTimeoutError(str(exc)) from exc
-            except RateLimitError as exc:
-                # TODO back off and retry downstream
-                logger.error(exc)
-                raise LLMRateLimitError(str(exc)) from exc
-            except BadRequestError as exc:
-                logger.error(exc)
-                msg = str(exc)
-                if "filtered" in msg and "content management policy" in msg:
-                    raise LLMContentPolicyViolationError(str(exc)) from exc
-                else:
-                    raise LLMBadRequestError(str(exc)) from exc
-            except APIError as exc:
-                logger.error(exc)
-                raise LLMError(str(exc)) from exc
+            async for attempt in AsyncRetrying(
+                wait=wait_exponential(multiplier=1, max=10),
+                stop=stop_after_delay(retry_budget),
+                retry=retry_if_exception_type((LLMTimeoutError, LLMRateLimitError)),
+                before_sleep=before_sleep_log(logger, logging.DEBUG),
+                after=after_log(logger, logging.DEBUG),
+                reraise=True,
+            ):
+                with attempt:
+                    response = await self._complete_once(
+                        system_message=system_message,
+                        user_message=user_message,
+                        tenant_id=tenant_id,
+                        timeout=timeout,
+                        response_format=response_format,
+                    )
 
         content = response.choices[0].message.content
         if content is None:

--- a/src/qfa/adapters/llm_client.py
+++ b/src/qfa/adapters/llm_client.py
@@ -4,14 +4,27 @@ import logging
 import re
 from typing import cast
 
-import openai
 from litellm import acompletion, completion_cost
+from litellm.exceptions import APIError, BadRequestError, RateLimitError, Timeout
 from litellm.utils import type_to_response_format_param
 from pydantic import BaseModel, ValidationError
-from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_exponential
+from tenacity import (
+    after_log,
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_delay,
+    wait_exponential,
+)
 
 from qfa.domain import AnalysisError, FeedbackTooLargeError
-from qfa.domain.errors import LLMError, LLMRateLimitError, LLMTimeoutError
+from qfa.domain.errors import (
+    LLMBadRequestError,
+    LLMContentPolicyViolationError,
+    LLMError,
+    LLMRateLimitError,
+    LLMTimeoutError,
+)
 from qfa.domain.models import LLMResponse, T_Response
 from qfa.domain.ports import LLMPort
 from qfa.utils import timed
@@ -174,6 +187,8 @@ class LiteLLMClient(LLMPort):
         wait=wait_exponential(multiplier=1, max=10),
         stop=stop_after_delay(60),
         retry=retry_if_exception_type((LLMTimeoutError, LLMRateLimitError)),
+        before_sleep=before_sleep_log(logger, logging.DEBUG),
+        after=after_log(logger, logging.DEBUG),
     )
     async def complete(
         self,
@@ -214,6 +229,9 @@ class LiteLLMClient(LLMPort):
 
         self._check_token_limit(system_message, user_message)
 
+        logger.debug(
+            "LiteLLMClient: dispatching message with timeout %.1f seconds", timeout
+        )
         with timed() as call_sw:
             try:
                 response = await acompletion(
@@ -231,13 +249,22 @@ class LiteLLMClient(LLMPort):
                     if issubclass(response_model, BaseModel)
                     else None,
                 )
-            except openai.APITimeoutError as exc:
+            except Timeout as exc:
+                # TODO retry
                 logger.error(exc)
                 raise LLMTimeoutError(str(exc)) from exc
-            except openai.RateLimitError as exc:
+            except RateLimitError as exc:
+                # TODO back off and retry downstream
                 logger.error(exc)
                 raise LLMRateLimitError(str(exc)) from exc
-            except openai.APIError as exc:
+            except BadRequestError as exc:
+                logger.error(exc)
+                msg = str(exc)
+                if "filtered" in msg and "content management policy" in msg:
+                    raise LLMContentPolicyViolationError(str(exc)) from exc
+                else:
+                    raise LLMBadRequestError(str(exc)) from exc
+            except APIError as exc:
                 logger.error(exc)
                 raise LLMError(str(exc)) from exc
 

--- a/src/qfa/adapters/presidio_anonymizer.py
+++ b/src/qfa/adapters/presidio_anonymizer.py
@@ -22,6 +22,26 @@ LANGUAGES_AND_ANONYMIZATION_MODEL_PAIRINGS = [
     {"lang_code": "xx", "model_name": "xx_ent_wiki_sm"},
 ]
 
+# spaCy's OntoNotes models emit entity labels that carry no PII meaning
+# (numbers, facilities, products, etc.). Presidio has no mapping for them,
+# so without this list it logs a "not mapped to a Presidio entity" warning
+# for each one on every document. Ignoring them silences the noise *and*
+# stops these tokens from being masked with spurious placeholders.
+NON_PII_NER_LABELS_TO_IGNORE = [
+    "CARDINAL",
+    "ORDINAL",
+    "QUANTITY",
+    "PERCENT",
+    "MONEY",
+    "FAC",
+    "PRODUCT",
+    "EVENT",
+    "WORK_OF_ART",
+    "LAW",
+    "LANGUAGE",
+    "MISC",
+]
+
 
 def detect_language(text: str) -> str:
     """Detect the language of ``text`` and return a Presidio-compatible language code.
@@ -56,6 +76,9 @@ class PresidioAnonymizer(AnonymizationPort):
                 nlp_configuration={
                     "nlp_engine_name": "spacy",
                     "models": LANGUAGES_AND_ANONYMIZATION_MODEL_PAIRINGS,
+                    "ner_model_configuration": {
+                        "labels_to_ignore": NON_PII_NER_LABELS_TO_IGNORE,
+                    },
                 }
             ).create_engine()
         )

--- a/src/qfa/api/composition.py
+++ b/src/qfa/api/composition.py
@@ -34,7 +34,7 @@ import logging
 import litellm
 import yaml
 
-from qfa.adapters.embedding import build_bge_m3_embedder
+from qfa.adapters.embedding import build_onnx_embedder
 from qfa.adapters.presidio_anonymizer import PresidioAnonymizer
 from qfa.domain.ports import EmbeddingPort, LLMPort
 from qfa.services.orchestrator import Orchestrator
@@ -61,18 +61,21 @@ def build_embedder(settings: EmbeddingSettings) -> EmbeddingPort | None:
     Returns
     -------
     EmbeddingPort | None
-        A fully-constructed ``BgeM3OnnxEmbedder``, or ``None`` when
-        ``model_path`` is empty.
+        A fully-constructed ``OnnxEmbedder`` (for the configured
+        ``EMBEDDING_MODEL_KIND``), or ``None`` when ``model_path`` is empty.
     """
     if not settings.model_path:
         logger.info(
             "EMBEDDING_MODEL_PATH not set — hierarchical mode requires it at runtime"
         )
         return None
-    return build_bge_m3_embedder(
+    return build_onnx_embedder(
+        model_kind=settings.model_kind,
         model_path=settings.model_path,
         tokenizer_path=settings.tokenizer_path or settings.model_path,
         revision_hash=settings.revision_hash,
+        dense_dim=settings.dense_dim,
+        max_tokens=settings.max_tokens,
         intra_op_num_threads=settings.intra_op_num_threads,
         batch_size=settings.batch_size,
     )

--- a/src/qfa/api/routes.py
+++ b/src/qfa/api/routes.py
@@ -125,7 +125,7 @@ async def analyze(
         populated for both modes whenever metadata permits; ``confidence``
         is populated only for ``hierarchical`` mode.
     """
-    deadline = datetime.now(UTC) + timedelta(seconds=120)
+    deadline = datetime.now(UTC) + timedelta(seconds=600)
 
     domain_feedback_records = tuple(
         FeedbackRecordModel(id=doc.id, text=doc.text, metadata=doc.metadata)

--- a/src/qfa/domain/errors.py
+++ b/src/qfa/domain/errors.py
@@ -44,6 +44,14 @@ class LLMTimeoutError(LLMError):
     """Raised when the LLM provider does not respond in time."""
 
 
+class LLMBadRequestError(LLMError):
+    """Raised when the LLM provider returns a 400 Bad Request response."""
+
+
+class LLMContentPolicyViolationError(LLMBadRequestError):
+    """Raised when the LLM provider rejects the request due to content policy."""
+
+
 class LLMRateLimitError(LLMError):
     """Raised when the LLM provider returns a rate-limit response."""
 

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Callable, ClassVar, TypeVar
+from typing import Callable, ClassVar, Optional, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -443,6 +443,9 @@ class Orchestrator:
         )
 
         # 1. Anonymise each record's text up front (before embed + LLM).
+        logger.info(
+            "Starting anonymization of %d records...", len(request.feedback_records)
+        )
         with timed() as anonymize_sw:
             anonymized_records, mapping = self._anonymize_records(
                 request.feedback_records, anonymize
@@ -541,11 +544,33 @@ class Orchestrator:
             return partial
 
         with timed() as map_sw:
-            partials: list[str] = list(
+            partials_with_exceptions: list[str | BaseException] = list(
                 await asyncio.gather(
-                    *(_map_one(i, chunk) for i, chunk in enumerate(chunks, start=1))
+                    *(_map_one(i, chunk) for i, chunk in enumerate(chunks, start=1)),
+                    return_exceptions=True,
                 )
             )
+            errors: list[BaseException] = []
+            partials: list[str | None] = []
+            for partial_or_exc in partials_with_exceptions:
+                if isinstance(partial_or_exc, BaseException):
+                    errors.append(partial_or_exc)
+                    partials.append(None)
+                else:
+                    partials.append(partial_or_exc)
+            # check if any errors occurred and log them.
+            # Iff ALL chunks failed, raise.
+            if errors:
+                if len(errors) == len(chunks):
+                    raise AnalysisError("mapping failed for all chunks")
+                else:
+                    logger.warning(
+                        "Errors mapping %d/%d chunks: %s",
+                        len(errors),
+                        len(chunks),
+                        str(errors),
+                    )
+
         chunk_sizes: list[int] = [len(chunk.records) for chunk in chunks]
         logger.info(
             "map phase: %d chunk(s) in %.2fs", len(chunks), map_sw.elapsed_seconds
@@ -556,7 +581,9 @@ class Orchestrator:
         #    confidence. They are independent, so overlap them — the shared
         #    semaphore keeps total LLM concurrency within ``max_concurrent_chunks``.
         async def _judge_all() -> list[float]:
-            async def _judge_one(index: int, chunk: Chunk, partial: str) -> float:
+            async def _judge_one(
+                index: int, chunk: Chunk, partial: Optional[str]
+            ) -> float:
                 logger.debug("starting judge chunk %d/%d", index, len(chunks))
                 with timed() as judge_sw:
                     score = await self._judge_chunk(
@@ -583,15 +610,23 @@ class Orchestrator:
                         for i, (chunk, partial) in enumerate(
                             zip(chunks, partials, strict=True), start=1
                         )
-                    )
+                    ),
                 )
             )
 
         async def _reduce() -> str:
-            logger.info("starting reduce phase over %d partial(s)", len(partials))
+            # Drop chunks whose map call failed (None). They contribute nothing
+            # to the synthesis, and passing None into build_reduce_user_message
+            # would raise (escape_for_tag_envelope expects a str). The failed
+            # chunks still lower confidence: _judge_all scores them 0.0 by
+            # keeping the full, position-aligned `partials` list.
+            successful_partials = tuple(p for p in partials if p is not None)
+            logger.info(
+                "starting reduce phase over %d partial(s)", len(successful_partials)
+            )
             return await self._reduce_partials(
                 anonymized_prompt,
-                tuple(partials),
+                successful_partials,
                 trend_table,
                 request.tenant_id,
                 deadline,
@@ -708,7 +743,7 @@ class Orchestrator:
     ) -> str:
         """Produce one partial analysis for a chunk (no judging).
 
-        The records are already anonymised. The leaf judge that scores this
+        The leaf judge that scores this
         partial runs separately (see :meth:`_judge_chunk`) so it can overlap the
         reduce phase, which depends only on the partials.
         """
@@ -726,7 +761,7 @@ class Orchestrator:
         self,
         analyst_prompt: str,
         records: tuple[FeedbackRecordModel, ...],
-        partial: str,
+        partial: Optional[str],
         tenant_id: str,
         deadline: datetime,
         semaphore: asyncio.Semaphore,
@@ -738,6 +773,9 @@ class Orchestrator:
         so judge failure lowers confidence rather than vanishing. Independent of
         the reduce phase, so it runs concurrently with it.
         """
+        if partial is None:
+            # something went wrong processing the partial.
+            return 0.0
         user_message = build_analyze_user_message(analyst_prompt, records)
         try:
             judge_system = build_analyze_judge_system_message(

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -533,15 +533,15 @@ class Orchestrator:
 
         # One semaphore bounds *every* hierarchical LLM call (map, leaf judge,
         # reduce) to ``max_concurrent_chunks``, so total concurrency stays
-        # capped even while the judge and reduce phases overlap below. cap=1
-        # therefore remains fully sequential.
+        # capped across all phases. cap=1 therefore remains fully sequential.
         max_in_flight = self._analyze_settings.max_concurrent_chunks
         semaphore = asyncio.Semaphore(max_in_flight)
 
         # 4. MAP: produce one partial per chunk, concurrently. Only the partials
         #    are on the critical path to REDUCE; the leaf-judge scores feed only
-        #    the final confidence, so judging is deferred to phase 5 and overlaps
-        #    REDUCE. ``asyncio.gather`` preserves chunk order, so partials and
+        #    the final confidence, so judging is deferred to phase 5, which runs
+        #    REDUCE first and then the judges (see that block for why).
+        #    ``asyncio.gather`` preserves chunk order, so partials and
         #    chunk_sizes stay aligned with ``chunks``.
         logger.info(
             "starting map phase: %d chunk(s), up to %d concurrent LLM call(s)",
@@ -598,11 +598,12 @@ class Orchestrator:
                 if len(errors) == len(chunks):
                     raise AnalysisError("mapping failed for all chunks")
                 else:
+                    error_classes = sorted({type(exc).__name__ for exc in errors})
                     logger.warning(
-                        "Errors mapping %d/%d chunks: %s",
+                        "Errors mapping %d/%d chunks: error_classes=%s",
                         len(errors),
                         len(chunks),
-                        str(errors),
+                        ",".join(error_classes),
                     )
 
         chunk_sizes: list[int] = [len(chunk.records) for chunk in chunks]
@@ -806,8 +807,8 @@ class Orchestrator:
 
         ``semaphore`` caps how many completions run at once across the whole
         hierarchical pipeline (map, leaf judge, reduce), so concurrency stays
-        within ``max_concurrent_chunks`` even while the judge and reduce phases
-        overlap. The deadline/timeout is computed *after* acquiring a slot, so a
+        within ``max_concurrent_chunks`` across every phase. The
+        deadline/timeout is computed *after* acquiring a slot, so a
         completion that queued behind others still honours the remaining budget
         (and raises ``AnalysisTimeoutError`` if the deadline passed while it
         waited).
@@ -848,9 +849,10 @@ class Orchestrator:
     ) -> str:
         """Produce one partial analysis for a chunk (no judging).
 
-        The leaf judge that scores this
-        partial runs separately (see :meth:`_judge_chunk`) so it can overlap the
-        reduce phase, which depends only on the partials.
+        The leaf judge that scores this partial runs as a separate phase
+        (see :meth:`_judge_chunk`), after reduce — both depend only on the
+        partials, and deferring the judges keeps a time-starved judge phase
+        from discarding the already-produced synthesis.
         """
         response = await self._bounded_complete(
             semaphore,

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -6,6 +6,7 @@ manages retries with exponential backoff, and enforces deadlines.
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Callable, ClassVar, Optional, TypeVar
@@ -63,7 +64,11 @@ from qfa.services.prompts import (
     build_analyze_judge_system_message,
     build_analyze_user_message,
 )
-from qfa.settings import AnalyzeSettings, OrchestratorSettings
+from qfa.settings import (
+    LLM_RETRY_BUDGET_MULTIPLIER,
+    AnalyzeSettings,
+    OrchestratorSettings,
+)
 from qfa.utils import timed
 
 logger = logging.getLogger(__name__)
@@ -211,6 +216,22 @@ class _ScoredCode:
             f"Category ({self.confidence_category:.2f}): {self.explanation_category} "
             f"Code ({self.confidence_code:.2f}): {self.explanation_code}"
         )
+
+
+@dataclass
+class _SlotTiming:
+    """Split timing for one semaphore-bounded hierarchical LLM call.
+
+    ``queued_seconds`` is the time spent waiting to acquire the concurrency
+    semaphore; ``call_seconds`` is the LLM completion itself, measured only
+    *after* the slot was acquired. Keeping them apart makes the per-chunk
+    debug lines honest: a single combined duration folds queue-wait into
+    "call time", so a 5s call that waited 100s in the queue looked like a
+    110s call (and like a near-timeout when it was nothing of the sort).
+    """
+
+    queued_seconds: float = 0.0
+    call_seconds: float = 0.0
 
 
 class Orchestrator:
@@ -416,11 +437,17 @@ class Orchestrator:
 
         Flow: anonymise each record → deterministic coding-trend table →
         embed record texts (synchronous, CPU-bound) → cluster (HDBSCAN) →
-        MAP each chunk (leaf LLM call + leaf judge) → REDUCE the partials
+        MAP each chunk to a partial (leaf LLM call) → REDUCE the partials
         (with the trend table), recursing when a chunk or the partial set
-        overflows the token budget. The returned ``confidence`` is the
-        coverage-weighted mean of the per-chunk judge scores; the minimum
-        chunk score is reported as a floor in ``uncertainty_explanation``.
+        overflows the token budget → leaf-JUDGE each partial for the
+        confidence. Reduce runs before the judges: the synthesis is the
+        deliverable and gets slot priority, while the judges only feed the
+        secondary confidence signal. The returned ``confidence`` is the
+        coverage-weighted mean of the per-chunk judge scores, computed over
+        only the chunks that were successfully judged — chunks whose map or
+        judge call failed are excluded (not scored 0.0) and their count is
+        reported in ``uncertainty_explanation``. ``confidence`` is ``None``
+        when no chunk could be judged.
 
         Anonymisation happens before embedding and before every LLM call.
         Guardrails are applied at both the map and reduce prompts.
@@ -527,6 +554,7 @@ class Orchestrator:
                 len(chunks),
                 len(chunk.records),
             )
+            timing = _SlotTiming()
             with timed() as chunk_sw:
                 partial = await self._map_chunk(
                     anonymized_prompt,
@@ -534,12 +562,15 @@ class Orchestrator:
                     request.tenant_id,
                     deadline,
                     semaphore,
+                    timing=timing,
                 )
             logger.debug(
-                "map chunk %d/%d done in %.2fs",
+                "map chunk %d/%d done in %.2fs (queued=%.2fs call=%.2fs)",
                 index,
                 len(chunks),
                 chunk_sw.elapsed_seconds,
+                timing.queued_seconds,
+                timing.call_seconds,
             )
             return partial
 
@@ -576,15 +607,20 @@ class Orchestrator:
             "map phase: %d chunk(s) in %.2fs", len(chunks), map_sw.elapsed_seconds
         )
 
-        # 5. JUDGE and REDUCE run concurrently. REDUCE needs only the partials;
-        #    the leaf judges score each partial against its own chunk for the
-        #    confidence. They are independent, so overlap them — the shared
-        #    semaphore keeps total LLM concurrency within ``max_concurrent_chunks``.
-        async def _judge_all() -> list[float]:
+        # 5. REDUCE first, then JUDGE. The synthesis is the deliverable, so it
+        #    gets first claim on the semaphore slots and short-circuits the
+        #    judges on failure (a reduce error propagates and we never spend
+        #    tokens judging a synthesis we're about to discard). The leaf judges
+        #    only feed the secondary ``confidence`` signal, so they run after and
+        #    absorb whatever deadline pressure remains. Sequencing costs little
+        #    wall-clock: judge and reduce share one semaphore, so they were
+        #    already time-slicing the same ``max_concurrent_chunks`` slots.
+        async def _judge_all() -> list[float | None]:
             async def _judge_one(
                 index: int, chunk: Chunk, partial: Optional[str]
-            ) -> float:
+            ) -> float | None:
                 logger.debug("starting judge chunk %d/%d", index, len(chunks))
+                timing = _SlotTiming()
                 with timed() as judge_sw:
                     score = await self._judge_chunk(
                         anonymized_prompt,
@@ -593,13 +629,17 @@ class Orchestrator:
                         request.tenant_id,
                         deadline,
                         semaphore,
+                        timing=timing,
                     )
                 logger.debug(
-                    "judge chunk %d/%d done: judge=%.2f in %.2fs",
+                    "judge chunk %d/%d done: judge=%s in %.2fs "
+                    "(queued=%.2fs call=%.2fs)",
                     index,
                     len(chunks),
-                    score,
+                    f"{score:.2f}" if score is not None else "excluded",
                     judge_sw.elapsed_seconds,
+                    timing.queued_seconds,
+                    timing.call_seconds,
                 )
                 return score
 
@@ -617,9 +657,10 @@ class Orchestrator:
         async def _reduce() -> str:
             # Drop chunks whose map call failed (None). They contribute nothing
             # to the synthesis, and passing None into build_reduce_user_message
-            # would raise (escape_for_tag_envelope expects a str). The failed
-            # chunks still lower confidence: _judge_all scores them 0.0 by
-            # keeping the full, position-aligned `partials` list.
+            # would raise (escape_for_tag_envelope expects a str). Such chunks
+            # are *excluded* from the confidence too (see _judge_chunk → None),
+            # rather than scored 0.0 — a dropped chunk is unverified, not
+            # unfaithful. Their absence is surfaced in uncertainty_explanation.
             successful_partials = tuple(p for p in partials if p is not None)
             logger.info(
                 "starting reduce phase over %d partial(s)", len(successful_partials)
@@ -633,19 +674,61 @@ class Orchestrator:
                 semaphore,
             )
 
-        logger.info("starting judge + reduce (concurrent)")
-        with timed() as judge_reduce_sw:
-            chunk_scores, synthesis = await asyncio.gather(_judge_all(), _reduce())
-        logger.info("judge + reduce in %.2fs", judge_reduce_sw.elapsed_seconds)
+        logger.info("starting reduce phase")
+        with timed() as reduce_sw:
+            synthesis = await _reduce()
+        logger.info("reduce phase in %.2fs", reduce_sw.elapsed_seconds)
 
-        # 6. Aggregate per-chunk faithfulness into one confidence.
-        confidence = self._coverage_weighted_mean(chunk_scores, chunk_sizes)
-        floor = min(chunk_scores) if chunk_scores else 0.0
-        uncertainty = (
-            f"Leaf-judged confidence is a coverage-weighted mean over "
-            f"{len(chunks)} chunk(s); the lowest single-chunk faithfulness "
-            f"was {floor:.2f}."
-        )
+        logger.info("starting judge phase")
+        with timed() as judge_sw:
+            try:
+                chunk_scores = await _judge_all()
+            except (LLMTimeoutError, AnalysisTimeoutError) as exc:
+                # The synthesis (the deliverable) is already produced; a judge
+                # phase that runs out of time must NOT discard it. Per-chunk
+                # judges already swallow these into None, so this is a phase-level
+                # backstop: treat every chunk as unjudged (confidence -> None) and
+                # fall through to the fast, pure-Python result assembly below.
+                logger.warning(
+                    "Judge phase aborted (%s); returning the synthesis with "
+                    "confidence unavailable.",
+                    type(exc).__name__,
+                )
+                chunk_scores = [None] * len(chunks)
+        logger.info("judge phase in %.2fs", judge_sw.elapsed_seconds)
+
+        # 6. Aggregate per-chunk faithfulness into one confidence. Chunks whose
+        #    judge timed out or errored (None) are EXCLUDED — they neither count
+        #    toward nor against the mean, so a time-starved judge cannot masquerade
+        #    as a faithfulness of 0.0. Confidence is None when nothing was judged.
+        judged = [
+            (score, weight)
+            for score, weight in zip(chunk_scores, chunk_sizes, strict=True)
+            if score is not None
+        ]
+        excluded = len(chunks) - len(judged)
+        confidence: float | None
+        if not judged:
+            confidence = None
+            uncertainty = (
+                f"Confidence unavailable: none of the {len(chunks)} chunk(s) "
+                f"could be leaf-judged (all judge calls failed or timed out)."
+            )
+        else:
+            judged_scores = [score for score, _ in judged]
+            judged_weights = [weight for _, weight in judged]
+            confidence = self._coverage_weighted_mean(judged_scores, judged_weights)
+            floor = min(judged_scores)
+            excluded_note = (
+                f" ({excluded} chunk(s) excluded: judge failed or timed out)"
+                if excluded
+                else ""
+            )
+            uncertainty = (
+                f"Leaf-judged confidence is a coverage-weighted mean over "
+                f"{len(judged)} of {len(chunks)} chunk(s){excluded_note}; the "
+                f"lowest single-chunk faithfulness was {floor:.2f}."
+            )
 
         # 7. De-anonymise the synthesis (retain PERSON placeholders as in `analyze`).
         analysis_text = synthesis
@@ -662,17 +745,20 @@ class Orchestrator:
         # (de-anonymisation and trend-table building are sub-millisecond).
         logger.info(
             "analyze_hierarchical done in %.2fs "
-            "(anonymise=%.2fs embed=%.2fs cluster=%.2fs map=%.2fs judge+reduce=%.2fs)",
+            "(anonymise=%.2fs embed=%.2fs cluster=%.2fs map=%.2fs "
+            "reduce=%.2fs judge=%.2fs)",
             anonymize_sw.elapsed_seconds
             + embed_sw.elapsed_seconds
             + cluster_sw.elapsed_seconds
             + map_sw.elapsed_seconds
-            + judge_reduce_sw.elapsed_seconds,
+            + reduce_sw.elapsed_seconds
+            + judge_sw.elapsed_seconds,
             anonymize_sw.elapsed_seconds,
             embed_sw.elapsed_seconds,
             cluster_sw.elapsed_seconds,
             map_sw.elapsed_seconds,
-            judge_reduce_sw.elapsed_seconds,
+            reduce_sw.elapsed_seconds,
+            judge_sw.elapsed_seconds,
         )
 
         return AnalysisResultModel(
@@ -712,6 +798,7 @@ class Orchestrator:
         tenant_id: str,
         response_model: type[T_Response],
         deadline: datetime,
+        timing: _SlotTiming | None = None,
     ) -> LLMResponse[T_Response]:
         """Run one LLM completion, bounded by ``semaphore`` and the deadline.
 
@@ -722,16 +809,31 @@ class Orchestrator:
         completion that queued behind others still honours the remaining budget
         (and raises ``AnalysisTimeoutError`` if the deadline passed while it
         waited).
+
+        When ``timing`` is supplied it is populated with the queue-wait and the
+        post-acquire call duration as two separate fields, so callers can log
+        them apart rather than reporting one combined number that hides how long
+        the call sat waiting for a slot.
         """
+        queue_start = time.perf_counter()
         async with semaphore:
+            acquired_at = time.perf_counter()
+            if timing is not None:
+                timing.queued_seconds = acquired_at - queue_start
+            # Compute the timeout only now: queue-wait already elapsed, so the
+            # per-call window reflects the budget that actually remains.
             timeout = self._check_deadline_and_get_timeout(deadline)
-            return await self._llm.complete(
-                system_message=system_message,
-                user_message=user_message,
-                tenant_id=tenant_id,
-                response_model=response_model,
-                timeout=timeout,
-            )
+            try:
+                return await self._llm.complete(
+                    system_message=system_message,
+                    user_message=user_message,
+                    tenant_id=tenant_id,
+                    response_model=response_model,
+                    timeout=timeout,
+                )
+            finally:
+                if timing is not None:
+                    timing.call_seconds = time.perf_counter() - acquired_at
 
     async def _map_chunk(
         self,
@@ -740,6 +842,7 @@ class Orchestrator:
         tenant_id: str,
         deadline: datetime,
         semaphore: asyncio.Semaphore,
+        timing: _SlotTiming | None = None,
     ) -> str:
         """Produce one partial analysis for a chunk (no judging).
 
@@ -754,6 +857,7 @@ class Orchestrator:
             tenant_id=tenant_id,
             response_model=str,
             deadline=deadline,
+            timing=timing,
         )
         return response.structured
 
@@ -765,17 +869,19 @@ class Orchestrator:
         tenant_id: str,
         deadline: datetime,
         semaphore: asyncio.Semaphore,
-    ) -> float:
+        timing: _SlotTiming | None = None,
+    ) -> float | None:
         """Leaf-judge a partial against its own (anonymised) chunk.
 
-        Returns the faithfulness score in ``[0, 1]``; on any judge failure the
-        score floors at 0.0 and is still counted in the coverage-weighted mean,
-        so judge failure lowers confidence rather than vanishing. Independent of
-        the reduce phase, so it runs concurrently with it.
+        Returns the faithfulness score in ``[0, 1]``, or ``None`` when the chunk
+        cannot be judged — either its map call failed (``partial is None``) or
+        the judge call itself failed/timed out. ``None`` means *excluded* from
+        the confidence aggregation (unverified ≠ unfaithful), not scored 0.0, so
+        a time-starved judge does not depress the reported confidence.
         """
         if partial is None:
-            # something went wrong processing the partial.
-            return 0.0
+            # The map call for this chunk failed; there is nothing to judge.
+            return None
         user_message = build_analyze_user_message(analyst_prompt, records)
         try:
             judge_system = build_analyze_judge_system_message(
@@ -790,6 +896,7 @@ class Orchestrator:
                 tenant_id=tenant_id,
                 response_model=AnalyzeJudgeResult,
                 deadline=deadline,
+                timing=timing,
             )
             return judge_response.structured.quality_score
         except (
@@ -802,7 +909,7 @@ class Orchestrator:
             logger.warning(
                 "Hierarchical leaf judge failed: error_class=%s", type(exc).__name__
             )
-            return 0.0
+            return None
 
     async def _reduce_partials(
         self,
@@ -1375,7 +1482,14 @@ class Orchestrator:
             raise AnalysisTimeoutError(
                 f"Insufficient time remaining ({remaining:.1f}s) for an LLM attempt"
             )
-        return min(self._llm_timeout_seconds, remaining)
+        # A single ``LLMPort.complete`` may retry internally, spending up to
+        # ``LLM_RETRY_BUDGET_MULTIPLIER`` times this per-attempt timeout in worst
+        # case (see ``qfa.adapters.llm_client``). Divide the remaining deadline
+        # by the same factor so even a fully-retried last call finishes before
+        # the deadline. With a generous deadline the per-call cap binds first, so
+        # this only bites as the deadline approaches.
+        per_attempt_budget = remaining / LLM_RETRY_BUDGET_MULTIPLIER
+        return min(self._llm_timeout_seconds, per_attempt_budget)
 
     def _check_coding_deadline(self, deadline: datetime) -> None:
         """Raise when the coding deadline is exceeded."""

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -674,7 +674,6 @@ class Orchestrator:
                 semaphore,
             )
 
-        logger.info("starting reduce phase")
         with timed() as reduce_sw:
             synthesis = await _reduce()
         logger.info("reduce phase in %.2fs", reduce_sw.elapsed_seconds)
@@ -919,21 +918,12 @@ class Orchestrator:
         tenant_id: str,
         deadline: datetime,
         semaphore: asyncio.Semaphore,
-        depth: int = 0,
     ) -> str:
         """Synthesise partials into one analysis, tree-reducing on overflow.
 
         ``semaphore`` bounds the reduce LLM calls together with the concurrently
         running leaf judges, so total pipeline concurrency stays within
         ``max_concurrent_chunks``.
-
-        ``depth`` is the recursion level (0 at the top-level call), threaded
-        through purely for log instrumentation: each reduce LLM call and each
-        tree-reduce split is logged at DEBUG with its depth, the group it is
-        working on (``i/N``), and a queued/call timing split — mirroring the
-        per-chunk visibility the map and judge phases already provide, so an
-        operator can see exactly which part of the (possibly multi-level)
-        synthesis is running and how much of the current level remains.
 
         If the reduce user message would exceed the token budget, the
         partials are split into budget-sized groups, each reduced to an
@@ -949,10 +939,6 @@ class Orchestrator:
         """
         system_message = build_reduce_system_message()
 
-        logger.debug(
-            "reduce depth=%d: synthesising %d partial(s)", depth, len(partials)
-        )
-
         def _fits(items: tuple[str, ...], table: CodingTrendTable | None) -> bool:
             user = build_reduce_user_message(
                 analyst_prompt=analyst_prompt,
@@ -964,34 +950,25 @@ class Orchestrator:
                 <= self._max_total_tokens
             )
 
-        # Base case: everything fits in one reduce call, or only one partial remains.
-        if len(partials) <= 1 or _fits(partials, trend_table):
-            user_message = build_reduce_user_message(
-                analyst_prompt=analyst_prompt,
-                partial_analyses=partials,
-                trend_table=trend_table,
-            )
-            timing = _SlotTiming()
-            with timed() as reduce_sw:
-                response = await self._bounded_complete(
-                    semaphore,
-                    system_message=system_message,
-                    user_message=user_message,
-                    tenant_id=tenant_id,
-                    response_model=str,
-                    deadline=deadline,
-                    timing=timing,
-                )
-            logger.debug(
-                "reduce depth=%d: single-call synthesis over %d partial(s) done "
-                "in %.2fs (queued=%.2fs call=%.2fs)",
-                depth,
-                len(partials),
-                reduce_sw.elapsed_seconds,
-                timing.queued_seconds,
-                timing.call_seconds,
+        async def _reduce_once(items: tuple[str, ...]) -> str:
+            """Synthesise ``items`` (with the trend table) in one reduce call."""
+            response = await self._bounded_complete(
+                semaphore,
+                system_message=system_message,
+                user_message=build_reduce_user_message(
+                    analyst_prompt=analyst_prompt,
+                    partial_analyses=items,
+                    trend_table=trend_table,
+                ),
+                tenant_id=tenant_id,
+                response_model=str,
+                deadline=deadline,
             )
             return response.structured
+
+        # Base case: everything fits in one reduce call, or only one partial remains.
+        if len(partials) <= 1 or _fits(partials, trend_table):
+            return await _reduce_once(partials)
 
         # Recursive case: group partials to budget, reduce each group, recurse.
         groups = self._group_partials_to_budget(
@@ -1002,72 +979,20 @@ class Orchestrator:
         # (every partial overflows on its own), we cannot shrink the partial
         # count further. Emit one reduce call over all partials to terminate.
         if all(len(g) == 1 for g in groups) and len(groups) == len(partials):
-            logger.debug(
-                "reduce depth=%d: %d partial(s) each overflow alone; convergence "
-                "safeguard emits one final reduce call over all of them",
-                depth,
-                len(partials),
-            )
-            user_message = build_reduce_user_message(
-                analyst_prompt=analyst_prompt,
-                partial_analyses=partials,
-                trend_table=trend_table,
-            )
-            timing = _SlotTiming()
-            with timed() as reduce_sw:
-                response = await self._bounded_complete(
-                    semaphore,
-                    system_message=system_message,
-                    user_message=user_message,
-                    tenant_id=tenant_id,
-                    response_model=str,
-                    deadline=deadline,
-                    timing=timing,
-                )
-            logger.debug(
-                "reduce depth=%d: safeguard synthesis over %d partial(s) done "
-                "in %.2fs (queued=%.2fs call=%.2fs)",
-                depth,
-                len(partials),
-                reduce_sw.elapsed_seconds,
-                timing.queued_seconds,
-                timing.call_seconds,
-            )
-            return response.structured
+            return await _reduce_once(partials)
 
         logger.debug(
-            "reduce depth=%d: %d partial(s) exceed the token budget -> %d group(s); "
-            "reducing each group, then recursing over the intermediates",
-            depth,
+            "reduce: %d partial(s) exceed the token budget; tree-reducing in "
+            "%d group(s)",
             len(partials),
             len(groups),
         )
-        intermediates: list[str] = []
-        for group_index, group in enumerate(groups, start=1):
-            logger.debug(
-                "reduce depth=%d: reducing group %d/%d (%d partial(s))",
-                depth,
-                group_index,
-                len(groups),
-                len(group),
+        intermediates = [
+            await self._reduce_partials(
+                analyst_prompt, group, None, tenant_id, deadline, semaphore
             )
-            intermediate = await self._reduce_partials(
-                analyst_prompt,
-                group,
-                None,
-                tenant_id,
-                deadline,
-                semaphore,
-                depth=depth + 1,
-            )
-            intermediates.append(intermediate)
-        logger.debug(
-            "reduce depth=%d: %d group(s) reduced to %d intermediate(s); "
-            "starting final reduce over the intermediates",
-            depth,
-            len(groups),
-            len(intermediates),
-        )
+            for group in groups
+        ]
         return await self._reduce_partials(
             analyst_prompt,
             tuple(intermediates),
@@ -1075,7 +1000,6 @@ class Orchestrator:
             tenant_id,
             deadline,
             semaphore,
-            depth=depth + 1,
         )
 
     def _group_partials_to_budget(

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -919,12 +919,21 @@ class Orchestrator:
         tenant_id: str,
         deadline: datetime,
         semaphore: asyncio.Semaphore,
+        depth: int = 0,
     ) -> str:
         """Synthesise partials into one analysis, tree-reducing on overflow.
 
         ``semaphore`` bounds the reduce LLM calls together with the concurrently
         running leaf judges, so total pipeline concurrency stays within
         ``max_concurrent_chunks``.
+
+        ``depth`` is the recursion level (0 at the top-level call), threaded
+        through purely for log instrumentation: each reduce LLM call and each
+        tree-reduce split is logged at DEBUG with its depth, the group it is
+        working on (``i/N``), and a queued/call timing split — mirroring the
+        per-chunk visibility the map and judge phases already provide, so an
+        operator can see exactly which part of the (possibly multi-level)
+        synthesis is running and how much of the current level remains.
 
         If the reduce user message would exceed the token budget, the
         partials are split into budget-sized groups, each reduced to an
@@ -939,6 +948,10 @@ class Orchestrator:
         always terminates.
         """
         system_message = build_reduce_system_message()
+
+        logger.debug(
+            "reduce depth=%d: synthesising %d partial(s)", depth, len(partials)
+        )
 
         def _fits(items: tuple[str, ...], table: CodingTrendTable | None) -> bool:
             user = build_reduce_user_message(
@@ -958,13 +971,25 @@ class Orchestrator:
                 partial_analyses=partials,
                 trend_table=trend_table,
             )
-            response = await self._bounded_complete(
-                semaphore,
-                system_message=system_message,
-                user_message=user_message,
-                tenant_id=tenant_id,
-                response_model=str,
-                deadline=deadline,
+            timing = _SlotTiming()
+            with timed() as reduce_sw:
+                response = await self._bounded_complete(
+                    semaphore,
+                    system_message=system_message,
+                    user_message=user_message,
+                    tenant_id=tenant_id,
+                    response_model=str,
+                    deadline=deadline,
+                    timing=timing,
+                )
+            logger.debug(
+                "reduce depth=%d: single-call synthesis over %d partial(s) done "
+                "in %.2fs (queued=%.2fs call=%.2fs)",
+                depth,
+                len(partials),
+                reduce_sw.elapsed_seconds,
+                timing.queued_seconds,
+                timing.call_seconds,
             )
             return response.structured
 
@@ -977,27 +1002,72 @@ class Orchestrator:
         # (every partial overflows on its own), we cannot shrink the partial
         # count further. Emit one reduce call over all partials to terminate.
         if all(len(g) == 1 for g in groups) and len(groups) == len(partials):
+            logger.debug(
+                "reduce depth=%d: %d partial(s) each overflow alone; convergence "
+                "safeguard emits one final reduce call over all of them",
+                depth,
+                len(partials),
+            )
             user_message = build_reduce_user_message(
                 analyst_prompt=analyst_prompt,
                 partial_analyses=partials,
                 trend_table=trend_table,
             )
-            response = await self._bounded_complete(
-                semaphore,
-                system_message=system_message,
-                user_message=user_message,
-                tenant_id=tenant_id,
-                response_model=str,
-                deadline=deadline,
+            timing = _SlotTiming()
+            with timed() as reduce_sw:
+                response = await self._bounded_complete(
+                    semaphore,
+                    system_message=system_message,
+                    user_message=user_message,
+                    tenant_id=tenant_id,
+                    response_model=str,
+                    deadline=deadline,
+                    timing=timing,
+                )
+            logger.debug(
+                "reduce depth=%d: safeguard synthesis over %d partial(s) done "
+                "in %.2fs (queued=%.2fs call=%.2fs)",
+                depth,
+                len(partials),
+                reduce_sw.elapsed_seconds,
+                timing.queued_seconds,
+                timing.call_seconds,
             )
             return response.structured
 
+        logger.debug(
+            "reduce depth=%d: %d partial(s) exceed the token budget -> %d group(s); "
+            "reducing each group, then recursing over the intermediates",
+            depth,
+            len(partials),
+            len(groups),
+        )
         intermediates: list[str] = []
-        for group in groups:
+        for group_index, group in enumerate(groups, start=1):
+            logger.debug(
+                "reduce depth=%d: reducing group %d/%d (%d partial(s))",
+                depth,
+                group_index,
+                len(groups),
+                len(group),
+            )
             intermediate = await self._reduce_partials(
-                analyst_prompt, group, None, tenant_id, deadline, semaphore
+                analyst_prompt,
+                group,
+                None,
+                tenant_id,
+                deadline,
+                semaphore,
+                depth=depth + 1,
             )
             intermediates.append(intermediate)
+        logger.debug(
+            "reduce depth=%d: %d group(s) reduced to %d intermediate(s); "
+            "starting final reduce over the intermediates",
+            depth,
+            len(groups),
+            len(intermediates),
+        )
         return await self._reduce_partials(
             analyst_prompt,
             tuple(intermediates),
@@ -1005,6 +1075,7 @@ class Orchestrator:
             tenant_id,
             deadline,
             semaphore,
+            depth=depth + 1,
         )
 
     def _group_partials_to_budget(

--- a/src/qfa/settings.py
+++ b/src/qfa/settings.py
@@ -78,6 +78,44 @@ class EmbeddingSettings(BaseSettings):
     model_path: str = ""
     tokenizer_path: str = ""
     revision_hash: str = ""
+    model_kind: Literal["bge-m3", "e5"] = Field(
+        default="e5",
+        description=(
+            "Embedding model *family*, which selects the adapter's output"
+            " handling: ``e5`` (default) mean-pools the token-level"
+            " ``last_hidden_state`` over the attention mask and prepends the"
+            " ``query: `` prefix every E5 input requires; ``bge-m3`` takes the"
+            " model's already-pooled ``dense_vecs`` head as-is. The dimension"
+            " and token cap are *per-artifact* and set separately"
+            " (``dense_dim`` / ``max_tokens``), so both e5-base (768-d) and"
+            " e5-small (384-d) share ``kind=e5``. Default is e5-base: smaller"
+            " and faster than BGE-M3 for a modest cross-lingual quality trade;"
+            " set ``kind=bge-m3`` + ``dense_dim=1024`` to use the stronger"
+            " model."
+        ),
+    )
+    dense_dim: int = Field(
+        default=768,
+        ge=1,
+        description=(
+            "Expected output dimensionality of the dense vector, validated"
+            " per batch so a mismatched artifact/config fails loud rather"
+            " than silently producing wrong-width vectors. multilingual-e5-base"
+            " (the default) is 768; multilingual-e5-small is 384; BGE-M3 is"
+            " 1024."
+        ),
+    )
+    max_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Tokenizer truncation cap. ``None`` uses the model family's"
+            " natural context: 8192 for ``bge-m3``, 512 for ``e5`` (its"
+            " XLM-R/MiniLM backbone's positional limit). Set an explicit"
+            " lower value to bound the per-record (and, since padding is to"
+            " the batch's longest row, per-batch) cost from long outliers."
+        ),
+    )
     intra_op_num_threads: int | None = None
     batch_size: int = Field(
         default=100,

--- a/src/qfa/settings.py
+++ b/src/qfa/settings.py
@@ -61,7 +61,7 @@ class LLMSettings(BaseSettings):
     api_key: SecretStr = Field(default=...)  # required, no default
     api_base: str = ""
     api_version: str = ""
-    timeout_seconds: float = 115.0
+    timeout_seconds: float = 115.0  # deadline for most endpoints is 120s. Settings this to 55s leaves room for at least one retry on error
     max_total_tokens: int = 100_000
     chars_per_token: int = 4
 
@@ -177,7 +177,7 @@ class AnalyzeSettings(BaseSettings):
         ),
     )
     max_concurrent_chunks: int = Field(
-        default=8,
+        default=16,
         ge=1,
         description=(
             "Maximum map-step chunks analysed concurrently (mode=hierarchical)."
@@ -188,7 +188,7 @@ class AnalyzeSettings(BaseSettings):
         ),
     )
     target_chunk_tokens: int = Field(
-        default=4_000,
+        default=2_000,
         ge=1,
         description=(
             "Target size (in estimated tokens) for a single map chunk"

--- a/src/qfa/settings.py
+++ b/src/qfa/settings.py
@@ -7,6 +7,16 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from qfa.domain.clustering_models import TrendPeriod
 from qfa.domain.models import TenantApiKey
 
+#: Worst-case retry budget of a single ``LLMPort.complete`` call, expressed as a
+#: multiple of the per-attempt ``timeout``. The LLM adapter retries transient
+#: failures (timeout, rate-limit) up to ``LLM_RETRY_BUDGET_MULTIPLIER * timeout``
+#: of wall-clock; the orchestrator divides the deadline-derived budget by the
+#: same factor when sizing a per-attempt timeout, so even the worst-case retry
+#: sequence of the last call in a phase still finishes before the request
+#: deadline. The adapter and orchestrator MUST read this one constant so the two
+#: stay in lock-step — they live in different layers and cannot share code.
+LLM_RETRY_BUDGET_MULTIPLIER: float = 3.0
+
 
 class LogSettings(BaseSettings):
     """Define settings for the logger."""
@@ -177,7 +187,7 @@ class AnalyzeSettings(BaseSettings):
         ),
     )
     max_concurrent_chunks: int = Field(
-        default=16,
+        default=64,
         ge=1,
         description=(
             "Maximum map-step chunks analysed concurrently (mode=hierarchical)."

--- a/src/qfa/settings.py
+++ b/src/qfa/settings.py
@@ -79,7 +79,7 @@ class LLMSettings(BaseSettings):
     api_key: SecretStr = Field(default=...)  # required, no default
     api_base: str = ""
     api_version: str = ""
-    timeout_seconds: float = 115.0  # deadline for most endpoints is 120s. Settings this to 55s leaves room for at least one retry on error
+    timeout_seconds: float = 115.0
     max_total_tokens: int = 100_000
     chars_per_token: int = 4
 

--- a/tests/adapters/test_embedding.py
+++ b/tests/adapters/test_embedding.py
@@ -1,20 +1,23 @@
-"""Tests for the BGE-M3 ONNX embedding adapter.
+"""Tests for the ONNX embedding adapter (BGE-M3 and E5 families).
 
 Why: the adapter is the one new external dependency behind ``EmbeddingPort``.
 These tests pin (1) the security posture asserted at construction
 (trust_remote_code disabled, no custom-op libs, a pinned revision hash,
-a local artifact path), and (2) the dense-only, input-ordered, fixed-width
-output contract — all without downloading a model, by injecting a fake
-session and tokenizer. The real-model cosine validation lives in a separate
-e2e-marked test.
+a local artifact path), (2) the dense-only, input-ordered, fixed-width
+output contract, and (3) the per-family output handling — BGE-M3's
+already-pooled head taken as-is vs E5's masked mean-pool of token vectors
+plus its ``query: `` prefix — all without downloading a model, by injecting
+a fake session and tokenizer. The real-model cosine validation lives in a
+separate e2e-marked test.
 """
 
+import math
 from typing import Any
 
 import numpy as np
 import pytest
 
-from qfa.adapters.embedding import BgeM3OnnxEmbedder
+from qfa.adapters.embedding import OnnxEmbedder
 from qfa.domain.ports import EmbeddingPort
 
 
@@ -28,8 +31,21 @@ class _FakeTokenizer:
         return {"input_ids": np.array(ids), "attention_mask": np.array(mask)}
 
 
+class _RecordingTokenizer:
+    """Records the exact texts it was called with (to assert prefixing)."""
+
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    def __call__(self, texts):
+        self.seen = list(texts)
+        ids = [[1, 2, 3, 0] for _ in texts]
+        mask = [[1, 1, 1, 0] for _ in texts]
+        return {"input_ids": np.array(ids), "attention_mask": np.array(mask)}
+
+
 class _FakeSession:
-    """Fake onnxruntime session emitting the shipped model's first output.
+    """Fake onnxruntime session emitting an already-pooled dense head.
 
     Mirrors the BGE-M3 ONNX build, whose first output ``dense_vecs`` is the
     already-pooled (CLS-pooled internally) dense vector — shape
@@ -45,22 +61,45 @@ class _FakeSession:
         return [np.ones((batch, 1024), dtype=np.float32)]
 
 
+class _FakeTokenLevelSession:
+    """Fake session emitting token-level ``last_hidden_state``.
+
+    Mirrors an E5 ONNX export: first output is ``(batch, seq, hidden)`` and
+    must be mean-pooled over the attention mask. Returns a fixed tensor so the
+    masked-mean arithmetic is exactly checkable.
+    """
+
+    def __init__(self, last_hidden: np.ndarray) -> None:
+        self.run_calls = 0
+        self._last_hidden = last_hidden
+
+    def run(self, output_names, inputs):
+        self.run_calls += 1
+        return [self._last_hidden]
+
+
 def _make_embedder(
     model_path: str = "/srv/models/bge-m3-onnx-int8/model.onnx",
     revision_hash: str = "sha256:deadbeef",
     session: Any = None,
     tokenizer: Any = None,
+    pooling: str = "pre_pooled",
+    query_prefix: str = "",
+    dense_dim: int = 1024,
     trust_remote_code: bool = False,
     custom_op_libraries: tuple[str, ...] = (),
     intra_op_num_threads: int | None = 4,
     batch_size: int = 100,
-) -> BgeM3OnnxEmbedder:
-    """Build a ``BgeM3OnnxEmbedder`` with sensible defaults for unit tests."""
-    return BgeM3OnnxEmbedder(
+) -> OnnxEmbedder:
+    """Build an ``OnnxEmbedder`` with sensible defaults for unit tests."""
+    return OnnxEmbedder(
         model_path=model_path,
         revision_hash=revision_hash,
         session=session if session is not None else _FakeSession(),
         tokenizer=tokenizer if tokenizer is not None else _FakeTokenizer(),
+        pooling=pooling,
+        query_prefix=query_prefix,
+        dense_dim=dense_dim,
         trust_remote_code=trust_remote_code,
         custom_op_libraries=custom_op_libraries,
         intra_op_num_threads=intra_op_num_threads,
@@ -69,12 +108,12 @@ def _make_embedder(
 
 
 def test_adapter_inherits_embedding_port() -> None:
-    """``BgeM3OnnxEmbedder`` explicitly inherits ``EmbeddingPort`` (AGENTS.md rule).
+    """``OnnxEmbedder`` explicitly inherits ``EmbeddingPort`` (AGENTS.md rule).
 
     Why: the explicit base class makes the port<->adapter link discoverable
     in IDEs; structural conformance alone is reserved for test fakes.
     """
-    assert issubclass(BgeM3OnnxEmbedder, EmbeddingPort)
+    assert issubclass(OnnxEmbedder, EmbeddingPort)
 
 
 def test_construction_rejects_trust_remote_code_true() -> None:
@@ -107,16 +146,25 @@ def test_construction_requires_pinned_revision_hash() -> None:
         _make_embedder(revision_hash="")
 
 
+def test_construction_rejects_unknown_pooling() -> None:
+    """An unrecognised ``pooling`` strategy raises at construction.
+
+    Why: pooling selects how the ONNX output becomes a vector; a typo'd or
+    unsupported value must fail loud rather than silently mishandle the
+    model's output shape.
+    """
+    with pytest.raises(ValueError, match="pooling"):
+        _make_embedder(pooling="max")
+
+
 def test_embed_returns_one_normalised_1024d_vector_per_text_in_order() -> None:
     """``embed`` returns one L2-normalised dense 1024-d vector per input, in order.
 
     Why: clustering depends on a fixed-width, order-preserving contract of
-    unit vectors; the shipped build's already-pooled ``dense_vecs`` is taken
-    as-is (no token pooling) and L2-normalised, and BGE-M3's sparse/ColBERT
-    outputs are explicitly unused.
+    unit vectors; the shipped BGE-M3 build's already-pooled ``dense_vecs`` is
+    taken as-is (no token pooling) and L2-normalised, and BGE-M3's
+    sparse/ColBERT outputs are explicitly unused.
     """
-    import math
-
     embedder = _make_embedder()
     vectors = embedder.embed(("first feedback", "second feedback"))
     assert len(vectors) == 2
@@ -124,6 +172,78 @@ def test_embed_returns_one_normalised_1024d_vector_per_text_in_order() -> None:
     assert all(isinstance(x, float) for x in vectors[0])
     # ones/sqrt(1024) is the L2-normalised unit vector -> norm 1.0.
     assert abs(math.sqrt(sum(x * x for x in vectors[0])) - 1.0) < 1e-5
+
+
+def test_mean_pooling_averages_token_vectors_over_attention_mask() -> None:
+    """``pooling="mean"`` masked-means token vectors, ignoring pad positions.
+
+    Why: E5 exports emit token-level ``last_hidden_state``; the adapter must
+    average over real tokens only (mask=1) and exclude padding, then
+    L2-normalise. A pad token carrying a huge vector must not leak into the
+    result — otherwise per-batch padding would corrupt every vector.
+    """
+    # batch=1, seq=3, hidden=4. Tokens 0,1 are real; token 2 is padding and
+    # carries a large vector that must be excluded by the mask.
+    last_hidden = np.array(
+        [[[2.0, 0.0, 0.0, 0.0], [0.0, 2.0, 0.0, 0.0], [9.0, 9.0, 9.0, 9.0]]],
+        dtype=np.float32,
+    )
+
+    class _MaskTokenizer:
+        def __call__(self, texts):
+            return {
+                "input_ids": np.array([[10, 11, 0]]),
+                "attention_mask": np.array([[1, 1, 0]]),
+            }
+
+    embedder = _make_embedder(
+        session=_FakeTokenLevelSession(last_hidden),
+        tokenizer=_MaskTokenizer(),
+        pooling="mean",
+        dense_dim=4,
+    )
+    (vector,) = embedder.embed(("one record",))
+    # masked mean of the two real tokens = [1, 1, 0, 0]; L2-normalised.
+    expected = [1 / math.sqrt(2), 1 / math.sqrt(2), 0.0, 0.0]
+    assert all(abs(got - exp) < 1e-6 for got, exp in zip(vector, expected, strict=True))
+
+
+def test_query_prefix_is_prepended_before_tokenizing() -> None:
+    """``query_prefix`` is prepended to every text before it reaches the tokenizer.
+
+    Why: E5 models are trained with a ``query: ``/``passage: `` prefix and
+    degrade without it; for symmetric clustering every record gets the same
+    ``query: `` prefix. The prefix must be applied at the tokenizer boundary,
+    not left to the caller.
+    """
+    recorder = _RecordingTokenizer()
+    embedder = _make_embedder(tokenizer=recorder, query_prefix="query: ")
+    embedder.embed(("water point dry", "clinic out of stock"))
+    assert recorder.seen == ["query: water point dry", "query: clinic out of stock"]
+
+
+def test_no_prefix_passes_text_through_unchanged() -> None:
+    """An empty ``query_prefix`` (BGE-M3) leaves the text untouched.
+
+    Why: BGE-M3 takes no prefix; prepending one would shift every vector and
+    silently degrade clustering. The default must be a true pass-through.
+    """
+    recorder = _RecordingTokenizer()
+    embedder = _make_embedder(tokenizer=recorder, query_prefix="")
+    embedder.embed(("verbatim text",))
+    assert recorder.seen == ["verbatim text"]
+
+
+def test_embed_rejects_dense_vectors_of_the_wrong_width() -> None:
+    """A model output whose width != ``dense_dim`` raises rather than passing through.
+
+    Why: ``dense_dim`` is the per-artifact contract; a mismatched artifact or
+    misconfigured dimension must fail loud, not feed wrong-width vectors into
+    clustering. Here the fake emits 1024-d but the embedder expects 768.
+    """
+    embedder = _make_embedder(dense_dim=768)  # fake session emits 1024-d
+    with pytest.raises(ValueError, match="768-d"):
+        embedder.embed(("mismatch",))
 
 
 def test_embed_uses_one_session_run_when_input_fits_one_batch() -> None:
@@ -175,3 +295,22 @@ def test_embed_empty_input_returns_empty_without_calling_session() -> None:
     embedder = _make_embedder(session=session)
     assert embedder.embed(()) == ()
     assert session.run_calls == 0
+
+
+def test_build_onnx_embedder_rejects_unknown_model_kind() -> None:
+    """``build_onnx_embedder`` rejects an unknown family before loading anything.
+
+    Why: ``model_kind`` selects pooling + prefix; an unknown value must fail
+    fast with a clear message, not after paying to load an ONNX session — the
+    family lookup happens before any artifact IO.
+    """
+    from qfa.adapters.embedding import build_onnx_embedder
+
+    with pytest.raises(ValueError, match="unknown model_kind"):
+        build_onnx_embedder(
+            model_kind="bogus",
+            model_path="/nonexistent.onnx",
+            tokenizer_path="/nonexistent.json",
+            revision_hash="sha256:abc",
+            dense_dim=768,
+        )

--- a/tests/adapters/test_llm_client.py
+++ b/tests/adapters/test_llm_client.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from litellm.exceptions import APIError, BadRequestError, RateLimitError, Timeout
 from pydantic import BaseModel, Field
+from tenacity import wait_fixed
 
 from qfa.adapters.llm_client import (
     _UNSUPPORTED_SCHEMA_KEYWORDS,
@@ -193,11 +194,13 @@ class TestLiteLLMClientCostFallback:
 class TestLiteLLMClientExceptionMapping:
     @pytest.mark.asyncio
     async def test_timeout_error_mapped(self):
-        """litellm.Timeout maps to the domain LLMTimeoutError.
+        """litellm.Timeout maps to the domain LLMTimeoutError on a single attempt.
 
         Why: litellm (not openai) is what acompletion raises; the adapter
         must translate the provider-specific timeout into our domain error so
-        callers depend only on qfa.domain.errors.
+        callers depend only on qfa.domain.errors. Targets ``_complete_once``
+        (one attempt) so the mapping is asserted without driving the retry
+        loop in ``complete``.
         """
         client = _make_client()
         with patch(
@@ -208,21 +211,21 @@ class TestLiteLLMClientExceptionMapping:
             ),
         ):
             with pytest.raises(LLMTimeoutError):
-                await client.complete.__wrapped__(
-                    client,
-                    SYSTEM_MSG,
-                    USER_MSG,
-                    TENANT_ID,
-                    str,
+                await client._complete_once(
+                    system_message=SYSTEM_MSG,
+                    user_message=USER_MSG,
+                    tenant_id=TENANT_ID,
                     timeout=TIMEOUT,
+                    response_format=None,
                 )
 
     @pytest.mark.asyncio
     async def test_rate_limit_error_mapped(self):
-        """litellm.RateLimitError maps to the domain LLMRateLimitError.
+        """litellm.RateLimitError maps to the domain LLMRateLimitError on one attempt.
 
         Why: same boundary-translation contract as the timeout case, for the
-        429 path the retry decorator keys off.
+        429 path the retry loop keys off. Targets ``_complete_once`` so the
+        mapping is asserted without retrying.
         """
         client = _make_client()
         with patch(
@@ -233,13 +236,12 @@ class TestLiteLLMClientExceptionMapping:
             ),
         ):
             with pytest.raises(LLMRateLimitError):
-                await client.complete.__wrapped__(
-                    client,
-                    SYSTEM_MSG,
-                    USER_MSG,
-                    TENANT_ID,
-                    str,
+                await client._complete_once(
+                    system_message=SYSTEM_MSG,
+                    user_message=USER_MSG,
+                    tenant_id=TENANT_ID,
                     timeout=TIMEOUT,
+                    response_format=None,
                 )
 
     @pytest.mark.asyncio
@@ -389,6 +391,105 @@ class TestLiteLLMClientExceptionMapping:
                     _StructuredResponse,
                     timeout=TIMEOUT,
                 )
+
+
+class TestLiteLLMClientRetry:
+    """`complete` retries transient failures up to its budget, then re-raises.
+
+    The retry waits are patched to be instant (``wait_fixed``) so these tests
+    assert the retry *behaviour* without sleeping through real backoff.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retries_transient_timeout_then_succeeds(self):
+        """A transient timeout is retried and the subsequent success is returned.
+
+        Why: the whole point of moving the retry into the body — a single
+        flaky timeout must not fail the call when a retry would succeed.
+        """
+        good = _make_mock_response()
+        client = _make_client()
+        with (
+            patch(
+                "qfa.adapters.llm_client.acompletion",
+                new_callable=AsyncMock,
+                side_effect=[
+                    Timeout(message="transient", model=MODEL, llm_provider="azure_ai"),
+                    good,
+                ],
+            ) as mock_ac,
+            patch("qfa.adapters.llm_client.completion_cost", return_value=0.0),
+            patch(
+                "qfa.adapters.llm_client.wait_exponential",
+                return_value=wait_fixed(0),
+            ),
+        ):
+            result = await client.complete(
+                SYSTEM_MSG, USER_MSG, TENANT_ID, str, timeout=TIMEOUT
+            )
+
+        assert result.structured == "This is the summary."
+        assert mock_ac.call_count == 2  # one failure, one success
+
+    @pytest.mark.asyncio
+    async def test_retries_exhausted_reraises_domain_error(self):
+        """When every attempt times out, the domain LLMTimeoutError is re-raised.
+
+        Why: ``reraise=True`` must surface the underlying domain error (not a
+        tenacity RetryError) once the budget is spent, and the call must make
+        more than one attempt. A tiny per-attempt timeout keeps the
+        ``stop_after_delay`` budget (3x) small so the loop ends in milliseconds.
+        """
+        client = _make_client()
+        with (
+            patch(
+                "qfa.adapters.llm_client.acompletion",
+                new_callable=AsyncMock,
+                side_effect=Timeout(
+                    message="always", model=MODEL, llm_provider="azure_ai"
+                ),
+            ) as mock_ac,
+            patch(
+                "qfa.adapters.llm_client.wait_exponential",
+                return_value=wait_fixed(0.01),
+            ),
+        ):
+            with pytest.raises(LLMTimeoutError):
+                await client.complete(
+                    SYSTEM_MSG, USER_MSG, TENANT_ID, str, timeout=0.01
+                )
+
+        assert mock_ac.call_count >= 2  # retried before giving up
+
+    @pytest.mark.asyncio
+    async def test_bad_request_is_not_retried(self):
+        """A non-transient BadRequest fails on the first attempt without retrying.
+
+        Why: bad requests are deterministic — retrying wastes the budget and a
+        held concurrency slot. Only timeout/rate-limit are transient.
+        """
+        client = _make_client()
+        with (
+            patch(
+                "qfa.adapters.llm_client.acompletion",
+                new_callable=AsyncMock,
+                side_effect=BadRequestError(
+                    message="invalid model parameter",
+                    model=MODEL,
+                    llm_provider="azure_ai",
+                ),
+            ) as mock_ac,
+            patch(
+                "qfa.adapters.llm_client.wait_exponential",
+                return_value=wait_fixed(0),
+            ),
+        ):
+            with pytest.raises(LLMBadRequestError):
+                await client.complete(
+                    SYSTEM_MSG, USER_MSG, TENANT_ID, str, timeout=TIMEOUT
+                )
+
+        assert mock_ac.call_count == 1  # not retried
 
 
 class TestProviderSafeResponseFormat:

--- a/tests/adapters/test_llm_client.py
+++ b/tests/adapters/test_llm_client.py
@@ -4,8 +4,8 @@ import json
 from math import isnan
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import openai
 import pytest
+from litellm.exceptions import APIError, BadRequestError, RateLimitError, Timeout
 from pydantic import BaseModel, Field
 
 from qfa.adapters.llm_client import (
@@ -13,7 +13,13 @@ from qfa.adapters.llm_client import (
     LiteLLMClient,
     _provider_safe_response_format,
 )
-from qfa.domain.errors import LLMError, LLMRateLimitError, LLMTimeoutError
+from qfa.domain.errors import (
+    LLMBadRequestError,
+    LLMContentPolicyViolationError,
+    LLMError,
+    LLMRateLimitError,
+    LLMTimeoutError,
+)
 from qfa.domain.models import LLMResponse
 
 MODEL = "azure_ai/mistral-large-2411"
@@ -187,11 +193,19 @@ class TestLiteLLMClientCostFallback:
 class TestLiteLLMClientExceptionMapping:
     @pytest.mark.asyncio
     async def test_timeout_error_mapped(self):
+        """litellm.Timeout maps to the domain LLMTimeoutError.
+
+        Why: litellm (not openai) is what acompletion raises; the adapter
+        must translate the provider-specific timeout into our domain error so
+        callers depend only on qfa.domain.errors.
+        """
         client = _make_client()
         with patch(
             "qfa.adapters.llm_client.acompletion",
             new_callable=AsyncMock,
-            side_effect=openai.APITimeoutError(request=MagicMock()),
+            side_effect=Timeout(
+                message="timed out", model=MODEL, llm_provider="azure_ai"
+            ),
         ):
             with pytest.raises(LLMTimeoutError):
                 await client.complete.__wrapped__(
@@ -205,15 +219,17 @@ class TestLiteLLMClientExceptionMapping:
 
     @pytest.mark.asyncio
     async def test_rate_limit_error_mapped(self):
+        """litellm.RateLimitError maps to the domain LLMRateLimitError.
+
+        Why: same boundary-translation contract as the timeout case, for the
+        429 path the retry decorator keys off.
+        """
         client = _make_client()
-        mock_resp = MagicMock()
-        mock_resp.status_code = 429
-        mock_resp.headers = {}
         with patch(
             "qfa.adapters.llm_client.acompletion",
             new_callable=AsyncMock,
-            side_effect=openai.RateLimitError(
-                message="rate limited", response=mock_resp, body=None
+            side_effect=RateLimitError(
+                message="rate limited", model=MODEL, llm_provider="azure_ai"
             ),
         ):
             with pytest.raises(LLMRateLimitError):
@@ -228,15 +244,68 @@ class TestLiteLLMClientExceptionMapping:
 
     @pytest.mark.asyncio
     async def test_generic_api_error_mapped(self):
+        """A generic litellm.APIError maps to the domain LLMError.
+
+        Why: provider errors that aren't timeout/rate-limit/bad-request fall
+        through to the catch-all branch and must surface as our base LLMError.
+        """
         client = _make_client()
         with patch(
             "qfa.adapters.llm_client.acompletion",
             new_callable=AsyncMock,
-            side_effect=openai.APIError(
-                message="server error", request=MagicMock(), body=None
+            side_effect=APIError(
+                status_code=500,
+                message="server error",
+                model=MODEL,
+                llm_provider="azure_ai",
             ),
         ):
             with pytest.raises(LLMError):
+                await client.complete(
+                    SYSTEM_MSG, USER_MSG, TENANT_ID, str, timeout=TIMEOUT
+                )
+
+    @pytest.mark.asyncio
+    async def test_content_policy_bad_request_mapped(self):
+        """A content-filtered BadRequestError maps to LLMContentPolicyViolationError.
+
+        Why: Azure signals content-policy blocks as a BadRequest whose message
+        mentions filtering + the content management policy; that case must be
+        distinguishable from other bad requests so callers can handle it.
+        """
+        client = _make_client()
+        with patch(
+            "qfa.adapters.llm_client.acompletion",
+            new_callable=AsyncMock,
+            side_effect=BadRequestError(
+                message="The response was filtered due to the content management policy",
+                model=MODEL,
+                llm_provider="azure_ai",
+            ),
+        ):
+            with pytest.raises(LLMContentPolicyViolationError):
+                await client.complete(
+                    SYSTEM_MSG, USER_MSG, TENANT_ID, str, timeout=TIMEOUT
+                )
+
+    @pytest.mark.asyncio
+    async def test_generic_bad_request_mapped(self):
+        """A non-content-policy BadRequestError maps to plain LLMBadRequestError.
+
+        Why: the content-policy branch must not swallow ordinary 400s; those
+        should surface as the generic bad-request domain error.
+        """
+        client = _make_client()
+        with patch(
+            "qfa.adapters.llm_client.acompletion",
+            new_callable=AsyncMock,
+            side_effect=BadRequestError(
+                message="invalid model parameter",
+                model=MODEL,
+                llm_provider="azure_ai",
+            ),
+        ):
+            with pytest.raises(LLMBadRequestError):
                 await client.complete(
                     SYSTEM_MSG, USER_MSG, TENANT_ID, str, timeout=TIMEOUT
                 )

--- a/tests/services/test_orchestrator_hierarchical.py
+++ b/tests/services/test_orchestrator_hierarchical.py
@@ -9,10 +9,11 @@ single_pass call is byte-identical to before (no regression).
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from qfa.domain.errors import AnalysisError, LLMError
+from qfa.domain.errors import AnalysisError, AnalysisTimeoutError, LLMError
 from qfa.domain.models import (
     AnalysisRequestModel,
     FeedbackRecordModel,
@@ -512,14 +513,17 @@ class OneChunkMapFailsLLM:
 
 
 @pytest.mark.asyncio
-async def test_partial_map_failure_still_reduces_and_lowers_confidence():
-    """One chunk's map failure doesn't abort the run; it drops from reduce, scores 0.0.
+async def test_partial_map_failure_excludes_chunk_from_confidence():
+    """One chunk's map failure doesn't abort the run; it is excluded from confidence.
 
     Why: regression for the partial-failure path. A failed map chunk becomes a
     ``None`` partial that MUST be filtered before the reduce prompt — passing
     None into ``build_reduce_user_message`` raised ``AttributeError`` and tore
-    down the whole analysis. The failed chunk still pulls confidence down via a
-    0.0 leaf-judge score rather than vanishing. Only an all-chunk failure raises.
+    down the whole analysis. The failed chunk has no partial to judge, so it is
+    *excluded* from the coverage-weighted confidence (unverified ≠ unfaithful):
+    confidence reflects only the surviving chunk's leaf score (0.8), and the
+    exclusion is reported in ``uncertainty_explanation``. Only an all-chunk
+    failure raises.
     """
     water = _records(4, "water access was limited " * 5, "w")
     health = _records(4, "health clinic medicine " * 5, "h")
@@ -544,10 +548,106 @@ async def test_partial_map_failure_still_reduces_and_lowers_confidence():
         c for c in llm.calls if c[2] is str and "<partial_analyses>" in c[1]
     ]
     assert reduce_calls, "reduce never ran after a partial map failure"
-    # The failed chunk's 0.0 leaf score pulls confidence below the surviving
-    # chunk's 0.8, but the surviving chunk keeps it above 0.0.
-    assert result.confidence is not None
-    assert 0.0 < result.confidence < 0.8
+    # The failed chunk is excluded, so confidence is exactly the surviving
+    # chunk's 0.8 (not dragged toward 0.0), and the exclusion is surfaced.
+    assert result.confidence == pytest.approx(0.8)
+    assert "excluded" in result.uncertainty_explanation
+
+
+class AllJudgesFailLLM:
+    """Map and reduce calls succeed, but every leaf-judge call raises.
+
+    Exercises the "nothing could be judged" path: the synthesis is produced
+    normally, yet confidence must come back ``None`` rather than 0.0.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    async def complete(
+        self, system_message, user_message, tenant_id, response_model=str, timeout=20.0
+    ):
+        """Raise on judge calls; return canned output for map and reduce."""
+        self.calls.append((system_message, user_message, response_model))
+        if response_model is AnalyzeJudgeResult:
+            raise LLMError("simulated judge failure")
+        return LLMResponse(
+            structured="PARTIAL_OR_REDUCE",
+            model="fake",
+            prompt_tokens=1,
+            completion_tokens=1,
+            cost=0.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_all_judges_failing_yields_none_confidence_with_synthesis():
+    """When every leaf judge fails, confidence is None but the synthesis stands.
+
+    Why: judge failures are excluded from confidence, so if *none* succeed there
+    is no faithfulness signal at all — confidence must be ``None`` (unavailable),
+    not 0.0 (verified-bad). The deliverable synthesis is independent of judging
+    and must still be returned.
+    """
+    water = _records(4, "water access was limited " * 5, "w")
+    health = _records(4, "health clinic medicine " * 5, "h")
+    request = AnalysisRequestModel(
+        feedback_records=water + health,
+        prompt="trends?",
+        tenant_id=TENANT_ID,
+        mode="hierarchical",
+    )
+    orch = _build_orchestrator(
+        AllJudgesFailLLM(),
+        RecordingAnonymizer(),
+        FakeEmbeddingPort(),
+        max_total_tokens=100_000,
+    )
+    deadline = datetime.now(UTC) + timedelta(seconds=120)
+
+    result = await orch.analyze_hierarchical(request, deadline, anonymize=True)
+
+    assert result.result  # synthesis produced
+    assert result.confidence is None
+    assert "unavailable" in result.uncertainty_explanation.lower()
+
+
+@pytest.mark.asyncio
+async def test_judge_phase_timeout_does_not_discard_synthesis():
+    """A timeout escaping the judge phase still yields the synthesis, confidence None.
+
+    Why: the synthesis is produced before judging, so a judge-phase timeout must
+    not tear down the whole request. Patching ``_judge_chunk`` to raise
+    ``AnalysisTimeoutError`` simulates a timeout escaping the per-chunk handling;
+    the phase-level backstop must catch it, mark confidence unavailable, and run
+    the pure-Python result assembly to completion.
+    """
+    water = _records(4, "water access was limited " * 5, "w")
+    health = _records(4, "health clinic medicine " * 5, "h")
+    request = AnalysisRequestModel(
+        feedback_records=water + health,
+        prompt="trends?",
+        tenant_id=TENANT_ID,
+        mode="hierarchical",
+    )
+    orch = _build_orchestrator(
+        RecordingLLM(),
+        RecordingAnonymizer(),
+        FakeEmbeddingPort(),
+        max_total_tokens=100_000,
+    )
+    deadline = datetime.now(UTC) + timedelta(seconds=120)
+
+    with patch.object(
+        Orchestrator,
+        "_judge_chunk",
+        new=AsyncMock(side_effect=AnalysisTimeoutError("judge deadline exceeded")),
+    ):
+        result = await orch.analyze_hierarchical(request, deadline, anonymize=True)
+
+    assert result.result  # synthesis assembled and returned
+    assert result.confidence is None
+    assert "unavailable" in result.uncertainty_explanation.lower()
 
 
 @pytest.mark.asyncio
@@ -603,14 +703,14 @@ async def test_all_chunks_failing_raises_analysis_error():
 
 
 @pytest.mark.asyncio
-async def test_judge_and_reduce_phases_overlap():
-    """Leaf judging runs concurrently with the reduce phase.
+async def test_reduce_runs_to_completion_before_any_judge():
+    """The reduce phase fully completes before the first leaf-judge call starts.
 
-    Why: reduce needs only the partials, while the leaf judges score those
-    partials for the confidence — independent work, so overlapping them
-    shortens wall-clock. With a generous concurrency cap (no semaphore
-    contention), a judge call and a reduce call are observed in flight at the
-    same time. The aggregated confidence and synthesis must still be produced.
+    Why: the synthesis is the deliverable, so it gets first claim on the
+    concurrency slots and short-circuits the judges on failure. Sequencing
+    reduce-before-judge means no judge call is ever in flight while a reduce
+    call runs, and every reduce call precedes every judge call in time. The
+    aggregated confidence and synthesis must still be produced.
     """
     request = _multi_chunk_request()
     llm = OverlapTrackingLLM()
@@ -627,10 +727,21 @@ async def test_judge_and_reduce_phases_overlap():
 
     result = await orch.analyze_hierarchical(request, deadline, anonymize=True)
 
-    assert llm.judge_reduce_overlap, "judge and reduce phases did not overlap"
-    reduce_calls = [
-        c for c in llm.calls if c[2] is str and "<partial_analyses>" in c[1]
+    # No judge call ever coexisted with a reduce call.
+    assert not llm.judge_reduce_overlap, "judge ran concurrently with reduce"
+    # Every reduce call strictly precedes every judge call in the recorded order.
+    kinds = [
+        "judge"
+        if c[2] is AnalyzeJudgeResult
+        else ("reduce" if "<partial_analyses>" in c[1] else "map")
+        for c in llm.calls
     ]
-    assert len(reduce_calls) >= 1
+    reduce_positions = [i for i, k in enumerate(kinds) if k == "reduce"]
+    judge_positions = [i for i, k in enumerate(kinds) if k == "judge"]
+    assert reduce_positions, "reduce never ran"
+    assert judge_positions, "judge never ran"
+    assert max(reduce_positions) < min(judge_positions), (
+        "a judge call started before the reduce phase finished"
+    )
     assert result.confidence is not None
     assert result.result

--- a/tests/services/test_orchestrator_hierarchical.py
+++ b/tests/services/test_orchestrator_hierarchical.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+from qfa.domain.errors import AnalysisError, LLMError
 from qfa.domain.models import (
     AnalysisRequestModel,
     FeedbackRecordModel,
@@ -469,6 +470,136 @@ class OverlapTrackingLLM:
             completion_tokens=1,
             cost=0.0,
         )
+
+
+class OneChunkMapFailsLLM:
+    """LLM whose map call fails for the 'health' cluster but succeeds elsewhere.
+
+    A map call is identified by ``response_model is str`` plus the
+    ``<feedback_records>`` envelope; when such a call carries 'health' text it
+    raises ``LLMError`` to simulate one chunk failing. Judge and reduce calls
+    answer normally. Used to exercise the partial-failure path.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    async def complete(
+        self, system_message, user_message, tenant_id, response_model=str, timeout=20.0
+    ):
+        """Raise on the 'health' map chunk; return canned output otherwise."""
+        self.calls.append((system_message, user_message, response_model))
+        is_map = response_model is str and "<feedback_records>" in user_message
+        if is_map and "health" in user_message:
+            raise LLMError("simulated map failure for one chunk")
+        if response_model is AnalyzeJudgeResult:
+            return LLMResponse(
+                structured=AnalyzeJudgeResult(
+                    quality_score=0.8, uncertainty_explanation="ok"
+                ),
+                model="fake",
+                prompt_tokens=1,
+                completion_tokens=1,
+                cost=0.0,
+            )
+        return LLMResponse(
+            structured="PARTIAL_OR_REDUCE",
+            model="fake",
+            prompt_tokens=1,
+            completion_tokens=1,
+            cost=0.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_partial_map_failure_still_reduces_and_lowers_confidence():
+    """One chunk's map failure doesn't abort the run; it drops from reduce, scores 0.0.
+
+    Why: regression for the partial-failure path. A failed map chunk becomes a
+    ``None`` partial that MUST be filtered before the reduce prompt — passing
+    None into ``build_reduce_user_message`` raised ``AttributeError`` and tore
+    down the whole analysis. The failed chunk still pulls confidence down via a
+    0.0 leaf-judge score rather than vanishing. Only an all-chunk failure raises.
+    """
+    water = _records(4, "water access was limited " * 5, "w")
+    health = _records(4, "health clinic medicine " * 5, "h")
+    request = AnalysisRequestModel(
+        feedback_records=water + health,
+        prompt="trends?",
+        tenant_id=TENANT_ID,
+        mode="hierarchical",
+    )
+    llm = OneChunkMapFailsLLM()
+    orch = _build_orchestrator(
+        llm, RecordingAnonymizer(), FakeEmbeddingPort(), max_total_tokens=100_000
+    )
+    deadline = datetime.now(UTC) + timedelta(seconds=120)
+
+    result = await orch.analyze_hierarchical(request, deadline, anonymize=True)
+
+    # The run completed despite one chunk failing — the reduce-phase regression.
+    assert result.result
+    # Reduce still ran; the surviving partial fed it (None was filtered out).
+    reduce_calls = [
+        c for c in llm.calls if c[2] is str and "<partial_analyses>" in c[1]
+    ]
+    assert reduce_calls, "reduce never ran after a partial map failure"
+    # The failed chunk's 0.0 leaf score pulls confidence below the surviving
+    # chunk's 0.8, but the surviving chunk keeps it above 0.0.
+    assert result.confidence is not None
+    assert 0.0 < result.confidence < 0.8
+
+
+@pytest.mark.asyncio
+async def test_all_chunks_failing_raises_analysis_error():
+    """When every map chunk fails, analyze_hierarchical raises AnalysisError.
+
+    Why: a partial failure degrades gracefully, but a total map failure has no
+    partials to synthesise, so it must surface as an error rather than an empty
+    result.
+    """
+
+    class AllMapsFailLLM(OneChunkMapFailsLLM):
+        """Every map call fails; judge/reduce never get the chance to run."""
+
+        async def complete(
+            self,
+            system_message,
+            user_message,
+            tenant_id,
+            response_model=str,
+            timeout=20.0,
+        ):
+            """Raise on every map call regardless of cluster."""
+            self.calls.append((system_message, user_message, response_model))
+            if response_model is str and "<feedback_records>" in user_message:
+                raise LLMError("simulated map failure for all chunks")
+            return LLMResponse(
+                structured="UNREACHED",
+                model="fake",
+                prompt_tokens=1,
+                completion_tokens=1,
+                cost=0.0,
+            )
+
+    water = _records(4, "water access was limited " * 5, "w")
+    health = _records(4, "health clinic medicine " * 5, "h")
+    request = AnalysisRequestModel(
+        feedback_records=water + health,
+        prompt="trends?",
+        tenant_id=TENANT_ID,
+        mode="hierarchical",
+    )
+    orch = _build_orchestrator(
+        AllMapsFailLLM(),
+        RecordingAnonymizer(),
+        FakeEmbeddingPort(),
+        max_total_tokens=100_000,
+    )
+    deadline = datetime.now(UTC) + timedelta(seconds=120)
+
+    with pytest.raises(AnalysisError, match="mapping failed for all chunks"):
+        await orch.analyze_hierarchical(request, deadline, anonymize=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -215,7 +215,7 @@ def test_embedding_settings_defaults_and_env_prefix(monkeypatch) -> None:
 
 
 def test_embedding_settings_select_bge_m3_family(monkeypatch) -> None:
-    """``EMBEDDING_MODEL_KIND``/``DENSE_DIM``/``MAX_TOKENS`` are env-configurable.
+    """``EMBEDDING_MODEL_KIND``/``EMBEDDING_DENSE_DIM``/``EMBEDDING_MAX_TOKENS`` are env-configurable.
 
     Why: the default is the smaller/faster e5-base, but switching to the
     stronger BGE-M3 (1024-d, pre-pooled) must be a pure config change — no code

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -207,6 +207,30 @@ def test_embedding_settings_defaults_and_env_prefix(monkeypatch) -> None:
     assert settings.revision_hash == "sha256:abc123"
     # Default thread count is None (leave onnxruntime core-count default).
     assert settings.intra_op_num_threads is None
+    # Family/dimension default to multilingual-e5-base (the default model);
+    # max_tokens=None means "use the family's natural context" (512 for e5).
+    assert settings.model_kind == "e5"
+    assert settings.dense_dim == 768
+    assert settings.max_tokens is None
+
+
+def test_embedding_settings_select_bge_m3_family(monkeypatch) -> None:
+    """``EMBEDDING_MODEL_KIND``/``DENSE_DIM``/``MAX_TOKENS`` are env-configurable.
+
+    Why: the default is the smaller/faster e5-base, but switching to the
+    stronger BGE-M3 (1024-d, pre-pooled) must be a pure config change — no code
+    edit — so an operator can trade latency for cross-lingual quality per
+    deployment.
+    """
+    from qfa.settings import EmbeddingSettings
+
+    monkeypatch.setenv("EMBEDDING_MODEL_PATH", "/srv/models/bge-m3/model.onnx")
+    monkeypatch.setenv("EMBEDDING_REVISION_HASH", "sha256:bge")
+    monkeypatch.setenv("EMBEDDING_MODEL_KIND", "bge-m3")
+    monkeypatch.setenv("EMBEDDING_DENSE_DIM", "1024")
+    settings = EmbeddingSettings()
+    assert settings.model_kind == "bge-m3"
+    assert settings.dense_dim == 1024
 
 
 def test_analyze_settings_have_clustering_and_trend_fields() -> None:


### PR DESCRIPTION
## What

Generalises the BGE-M3-only embedder into a **model-family-aware adapter** behind the unchanged `EmbeddingPort`, and **switches the default embedding model to `multilingual-e5-base`** (768-d) — smaller and faster on CPU than BGE-M3, which is the dominant latency cost on the hierarchical path for short multilingual feedback.

> **Heads-up — production default change:** the default embedder is now e5-base, not BGE-M3. Only e5-base is baked into the image; to run BGE-M3 again, bake it in (add a fetch step in the Dockerfile model stage) and set `EMBEDDING_MODEL_KIND=bge-m3` + `EMBEDDING_DENSE_DIM=1024`.

> ### ⚠️ Scope note — this branch carries more than its title
> Beyond the embedding feature, this branch also bundles a few **logically
> independent** changes (see "Additional changes" below): analyze-path
> hardening, an LLM error-mapping change, and reduce-phase logging. They are
> listed here so the description matches the diff, but they would ideally be
> **split out** — review the embedding change on its own merits and treat the
> rest as incidental. (Two other changes — a Presidio log tweak and a
> devcontainer statusline cosmetic — have **already been extracted** to their
> own PRs; see "Already extracted" below.) **Base:** stacked on
> `feat/corpus-runner` (#135), itself on #134.

## How (Proposal A — parameterize the one adapter)

- `BgeM3OnnxEmbedder` → `OnnxEmbedder` (still explicitly inherits the port). The only behavioural fork is output handling:
  - `pooling="pre_pooled"` — BGE-M3's already-pooled `dense_vecs` head, taken as-is.
  - `pooling="mean"` — mean-pool token-level `last_hidden_state` over the attention mask (E5), plus a `"query: "` prefix prepended before tokenizing.
  - Security posture (`trust_remote_code=False`, no custom ops, pinned hash) unchanged and written once.
- New settings: `EMBEDDING_MODEL_KIND` (`e5`|`bge-m3`) picks the family; `EMBEDDING_DENSE_DIM` and `EMBEDDING_MAX_TOKENS` are **per-artifact** knobs (so e5-base 768-d and e5-small 384-d share `kind=e5`). `dense_dim` is validated per batch → mismatched artifact/config fails loud; `max_tokens=None` → family default (8192 bge-m3 / 512 e5).
- `build_onnx_embedder` is the generic factory; `build_bge_m3_embedder` retained as a thin wrapper so the e2e cosine-vs-official validation is untouched. The embedder now also takes a `max_tokens` so its silent-truncation warning matches the tokenizer's configured cap.
- **Dockerfile** bakes only the default model (e5-base); runtime ENV points at it. bge-m3 is *not* baked — to run another family, add a fetch step in the model stage and override the `EMBEDDING_*` env. **`fetch_embedding_model.py`** gains a `--model {e5-base,e5-small,bge-m3}` registry (official intfloat int8 ONNX exports, pinned by commit) and prints all `EMBEDDING_*` lines including kind/dim.
- Docs: settings-reference rows + intro, ADR-014 addendum, hierarchical "why an embedding model", scripts/README.

## Additional changes in this branch (separable from the embedding feature)

These rode along on the branch and are **candidates to split out**:

- **`feat(orchestrator)`** — tolerate partial map-chunk failures in hierarchical analysis (a failed chunk no longer fails the whole request; surfaced in confidence). `orchestrator.py`.
- **`chore(analyze)`** — widen the analyze deadline and retune hierarchical chunking/concurrency; sequence reduce before judge and harden LLM retries. `orchestrator.py`, `settings.py`.
- **`feat(analyze)`** — per-call reduce-phase logging, then a follow-up that simplifies it (coarse breadcrumb + `_reduce_once`, drops `_SlotTiming` from reduce). `orchestrator.py`, `observability.md`.
- **`feat(llm)`** — map litellm content-policy / bad-request errors to domain errors. `llm_client.py`, `errors.py`. (Entangled with #135's llm_client rewrite — it builds on `_provider_safe_response_format`/`timed()`, which don't exist on `main` — so it stays on the stack rather than going to `main` standalone.)
- **`chore`** — mark generated corpus fixtures `linguist-generated` (`.gitattributes`).
- Merge of `feat/corpus-runner` into this branch to resolve drift (conflict resolution in `settings.py` / `embedding.py`).

### Already extracted to standalone PRs (review them there)

- **#145** — `chore(statusline)`: devcontainer progress bars + UTF-8 width fix (`.devcontainer/dotfiles/statusline-command.sh`).
- **#146** — `feat(anonymizer)`: silence non-PII spaCy NER labels in Presidio logs (`presidio_anonymizer.py`).

These two commits still appear in this branch's diff, but they are **not extra work to review here** — review them in #145/#146. They drop automatically when the stack rebases onto `main` after those land (identical patches → patch-id dedup).

## Verification

- `make lint` clean (ruff, ruff-format, ty, 3 import contracts KEPT).
- `make test` green; `make docs` green (a previously-failing Sphinx RST literal in the embedding module docstring is fixed). New tests: mean-pooling masked-mean, `"query: "` prefix application, dim-validation, unknown-kind/pooling guards, e5 settings.
- **Real-artifact smoke test** of e5-base through the adapter: 768-d unit vectors; EN/FR paraphrase cosine **0.899** > unrelated **0.767** (cross-lingual sanity holds).

## Notes / follow-ups

- **Recommended:** the statusline + anonymizer pieces are already extracted (#145/#146); the remaining "Additional changes" could likewise be split so the embedding change can be reviewed and reverted independently. (The LLM error-mapping change is the exception — it's coupled to #135's llm_client work and belongs on the stack.)
- `.env.example` is updated in this branch; the settings reference documents all new vars.
- A measured embed-vs-LLM wall-clock comparison (e5-base vs BGE-M3 via `stress_analyze.py`) shows significant speed-up (BGE-M3: impossibly slow, e5-base: 80 seconds for 5000 synthetic documents on my machine without GPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

