### PR TITLE
feat(assign-codes)!: return full coding hierarchy, drop code_id (#149)

### DIFF
--- a/docs/ubiquitous_language.md
+++ b/docs/ubiquitous_language.md
@@ -19,7 +19,10 @@ name in all contexts such as code, documentation, dashboards and training materi
 | Feedback metadata | Contextual attributes that describe a feedback record for governance, analysis, and responsibility, including operational and ethical flags. | Extra fields, system data |
 | Feedback dataset | Analytical abstraction that supports aggregation, filtering, and ML workflows across storage backends; may be derived or time‑bound. | Database, table |
 | Coding | Standard qualitative analysis practice emphasising interpretation; a single feedback record may be coded multiple times. | Tagging only |
-| Coding framework | Flexible, evolving structure for organising codes; supports iteration and learning over fixed classification. | Taxonomy, list of tags |
+| Coding framework | Flexible, evolving structure for organising codes; supports iteration and learning over fixed classification. A framework is a three-level hierarchy of **coding type → coding category → code**, and every assignment names all three levels. | Taxonomy, list of tags |
+| Coding type | The top (level 1) node of the coding framework; the broadest grouping under which categories and codes are nested. Surfaced as `type_label` on an assigned code. | Theme (when used loosely), tag |
+| Coding category | The middle (level 2) node of the coding framework, nested under a coding type and grouping the leaf codes. Surfaced as `category_label` on an assigned code. | Subtype, sub-tag |
+| Code | The leaf (level 3) node of the coding framework; the most specific label actually assigned to a feedback record. Surfaced as `code_label` on an assigned code. | Tag (leaf), label (generic) |
 | Auto‑coding | Tool‑neutral term for automated analysis; produces suggested codes that require human validation. | AI tagging |
 | Manual coding | Explicitly denotes human interpretation, enabling clear mixed human–AI workflows. | Human tagging |
 | Community member | This is the person giving feedback to a Red Cross/Red Crescent National Society. People‑centred term aligned with IFRC CEA commitments, emphasising rights and participation; never referred to as a user. | Beneficiary, client |

--- a/src/qfa/api/routes.py
+++ b/src/qfa/api/routes.py
@@ -283,7 +283,17 @@ async def assign_codes(
     orchestrator: Orchestrator = Depends(get_orchestrator),
     _scope: CallContext = Depends(call_scope_for(Operation.ASSIGN_CODES)),
 ) -> ApiAssignCodesResponse:
-    """Assign codes via iterative LLM picks at each level of the framework."""
+    """Assign codes via iterative LLM picks at each level of the framework.
+
+    The orchestrator walks the framework one level at a time (Type →
+    Category → Code), keeping the highest-confidence leaf codes up to
+    ``max_codes``. Each entry in the response reports the full hierarchy
+    path of the selected leaf: ``type_label`` (level 1), ``category_label``
+    (level 2), and ``code_label`` (level 3, the leaf). Because the inbound
+    ``coding_levels`` nodes carry only names (no stable ids), ``code_id``
+    mirrors the leaf ``code_label``; consumers such as EspoCRM map the
+    three levels back to their records by name (#149).
+    """
     deadline = datetime.now(UTC) + timedelta(seconds=120)
 
     domain_request = CodingAssignmentRequestModel(
@@ -309,6 +319,8 @@ async def assign_codes(
         assigned_codes=[
             ApiAssignedCode(
                 code_id=assigned.code_id,
+                type_label=assigned.type_label,
+                category_label=assigned.category_label,
                 code_label=assigned.code_label,
                 confidence_type=assigned.confidence_type,
                 confidence_category=assigned.confidence_category,

--- a/src/qfa/api/routes.py
+++ b/src/qfa/api/routes.py
@@ -289,10 +289,10 @@ async def assign_codes(
     Category → Code), keeping the highest-confidence leaf codes up to
     ``max_codes``. Each entry in the response reports the full hierarchy
     path of the selected leaf: ``type_label`` (level 1), ``category_label``
-    (level 2), and ``code_label`` (level 3, the leaf). Because the inbound
-    ``coding_levels`` nodes carry only names (no stable ids), ``code_id``
-    mirrors the leaf ``code_label``; consumers such as EspoCRM map the
-    three levels back to their records by name (#149).
+    (level 2), and ``code_label`` (level 3, the leaf). The inbound
+    ``coding_levels`` nodes carry only names (no stable ids), so consumers
+    such as EspoCRM map all three levels back to their records by name
+    (#149).
     """
     deadline = datetime.now(UTC) + timedelta(seconds=120)
 
@@ -318,7 +318,6 @@ async def assign_codes(
     return ApiAssignCodesResponse(
         assigned_codes=[
             ApiAssignedCode(
-                code_id=assigned.code_id,
                 type_label=assigned.type_label,
                 category_label=assigned.category_label,
                 code_label=assigned.code_label,

--- a/src/qfa/api/schemas.py
+++ b/src/qfa/api/schemas.py
@@ -512,8 +512,19 @@ class ApiAssignCodesRequest(ApiSingleInferenceRequestBase):
 class ApiAssignedCode(BaseModel):
     """A single code assigned to a feedback record."""
 
-    code_id: str
-    code_label: str
+    code_id: str = Field(
+        description=(
+            "Stable identifier from the coding framework. The framework "
+            "nodes carry only names, so this mirrors ``code_label``."
+        )
+    )
+    type_label: str = Field(description="Type-level (level 1) name of the assignment.")
+    category_label: str = Field(
+        description="Category-level (level 2) name of the assignment."
+    )
+    code_label: str = Field(
+        description="Code-level (level 3, leaf) name of the assignment."
+    )
     confidence_type: float
     confidence_category: float
     confidence_code: float

--- a/src/qfa/api/schemas.py
+++ b/src/qfa/api/schemas.py
@@ -512,12 +512,6 @@ class ApiAssignCodesRequest(ApiSingleInferenceRequestBase):
 class ApiAssignedCode(BaseModel):
     """A single code assigned to a feedback record."""
 
-    code_id: str = Field(
-        description=(
-            "Stable identifier from the coding framework. The framework "
-            "nodes carry only names, so this mirrors ``code_label``."
-        )
-    )
     type_label: str = Field(description="Type-level (level 1) name of the assignment.")
     category_label: str = Field(
         description="Category-level (level 2) name of the assignment."

--- a/src/qfa/domain/models.py
+++ b/src/qfa/domain/models.py
@@ -233,6 +233,8 @@ class AssignedCodeModel(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     code_id: str = Field(description="Stable identifier from the coding framework.")
+    type_label: str = Field(description="Human-readable Type-level name.")
+    category_label: str = Field(description="Human-readable Category-level name.")
     code_label: str = Field(description="Human-readable code name.")
     confidence_type: float = Field(
         description="Judge confidence that the Type level fits the feedback record (0-1)."

--- a/src/qfa/domain/models.py
+++ b/src/qfa/domain/models.py
@@ -232,7 +232,6 @@ class AssignedCodeModel(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    code_id: str = Field(description="Stable identifier from the coding framework.")
     type_label: str = Field(description="Human-readable Type-level name.")
     category_label: str = Field(description="Human-readable Category-level name.")
     code_label: str = Field(description="Human-readable code name.")

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -199,7 +199,6 @@ def _build_judge_system_message(source_text: str, summary: str) -> str:
 
 @dataclass
 class _ScoredCode:
-    code_id: str
     type_label: str
     category_label: str
     code_label: str
@@ -1312,7 +1311,6 @@ class Orchestrator:
 
                     candidates.append(
                         _ScoredCode(
-                            code_id=code_name,
                             type_label=type_name,
                             category_label=category_name,
                             code_label=code_name,
@@ -1333,7 +1331,6 @@ class Orchestrator:
                 feedback_record_id=feedback_record.id,
                 assigned_codes=tuple(
                     AssignedCodeModel(
-                        code_id=c.code_id,
                         type_label=c.type_label,
                         category_label=c.category_label,
                         code_label=c.code_label,

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -200,6 +200,8 @@ def _build_judge_system_message(source_text: str, summary: str) -> str:
 @dataclass
 class _ScoredCode:
     code_id: str
+    type_label: str
+    category_label: str
     code_label: str
     confidence_type: float
     confidence_category: float
@@ -1311,6 +1313,8 @@ class Orchestrator:
                     candidates.append(
                         _ScoredCode(
                             code_id=code_name,
+                            type_label=type_name,
+                            category_label=category_name,
                             code_label=code_name,
                             confidence_type=judge_type.score,
                             confidence_category=judge_category.score,
@@ -1330,6 +1334,8 @@ class Orchestrator:
                 assigned_codes=tuple(
                     AssignedCodeModel(
                         code_id=c.code_id,
+                        type_label=c.type_label,
+                        category_label=c.category_label,
                         code_label=c.code_label,
                         confidence_type=c.confidence_type,
                         confidence_category=c.confidence_category,

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -190,7 +190,6 @@ class FakeOrchestrator:
                     feedback_record_id=request.feedback_record.id,
                     assigned_codes=(
                         AssignedCodeModel(
-                            code_id="code-1",
                             type_label="Test type",
                             category_label="Test category",
                             code_label="Test code",

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -191,6 +191,8 @@ class FakeOrchestrator:
                     assigned_codes=(
                         AssignedCodeModel(
                             code_id="code-1",
+                            type_label="Test type",
+                            category_label="Test category",
                             code_label="Test code",
                             confidence_type=0.9,
                             confidence_category=0.85,

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -592,6 +592,21 @@ class TestAssignCodesSuccess:
         assert "explanation" in code_item
 
     @pytest.mark.asyncio
+    async def test_response_includes_full_coding_hierarchy_labels(self, client):
+        """Response exposes Type and Category labels alongside the leaf code.
+
+        So EspoCRM can map an assignment to all three coding levels (#149).
+        """
+        resp = await client.post(
+            "/v1/assign-codes", json=_CODING_BODY, headers=_auth_header()
+        )
+        assert resp.status_code == 200
+        code_item = resp.json()["assigned_codes"][0]
+        assert code_item["type_label"] == "Test type"
+        assert code_item["category_label"] == "Test category"
+        assert code_item["code_label"] == "Test code"
+
+    @pytest.mark.asyncio
     async def test_422_on_invalid_confidence_threshold(self, client):
         resp = await client.post(
             "/v1/assign-codes",

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -605,6 +605,8 @@ class TestAssignCodesSuccess:
         assert code_item["type_label"] == "Test type"
         assert code_item["category_label"] == "Test category"
         assert code_item["code_label"] == "Test code"
+        # code_id was dropped: it only ever mirrored code_label (#149).
+        assert "code_id" not in code_item
 
     @pytest.mark.asyncio
     async def test_422_on_invalid_confidence_threshold(self, client):

--- a/tests/services/test_orchestrator.py
+++ b/tests/services/test_orchestrator.py
@@ -12,6 +12,9 @@ from qfa.domain.models import (
     AggregateSummaryResultModel,
     AnalysisRequestModel,
     AnalysisResultModel,
+    CodingAssignmentRequestModel,
+    CodingFramework,
+    CodingNode,
     FeedbackRecordModel,
     FeedbackRecordSummaryModel,
     LLMResponse,
@@ -24,6 +27,7 @@ from qfa.domain.models import (
 )
 from qfa.domain.ports import AnonymizationPort, LLMPort
 from qfa.domain.sensitivity_types import SensitivityType
+from qfa.services.coding_classifier import JudgeResponse
 from qfa.services.orchestrator import Orchestrator
 from qfa.settings import OrchestratorSettings
 
@@ -1074,3 +1078,55 @@ class TestAnalyzeAnonymizationOrdering:
         judge_system = fake_llm.calls[1]["system_message"]
         assert sensitive_token not in judge_system
         assert "<PERSON_0>" in judge_system
+
+
+class TestAssignCodes:
+    """Tests for hierarchical code assignment."""
+
+    @pytest.mark.asyncio
+    async def test_assigned_code_carries_type_and_category_labels(self, settings):
+        """Each assigned code carries its full Type/Category/Code labels.
+
+        Not just the leaf Code label, so EspoCRM can map an assignment back
+        to all three coding levels (#149).
+        """
+        framework = CodingFramework(
+            root_codes=[
+                CodingNode(
+                    name="Type A",
+                    children=[
+                        CodingNode(
+                            name="Cat A1",
+                            children=[CodingNode(name="Code A1.1")],
+                        )
+                    ],
+                )
+            ]
+        )
+        request = CodingAssignmentRequestModel(
+            feedback_record=_make_feedback_record(),
+            coding_levels=framework,
+            max_codes=5,
+            tenant_id=TENANT_ID,
+        )
+        # 6 calls in order: pick-Types, judge-Type, pick-Categories,
+        # judge-Category, pick-Codes, judge-Code.
+        pick = _make_llm_response(structured='{"selected": [0]}')
+        judge = _make_llm_response(
+            structured=JudgeResponse(score=0.9, explanation="fits well")
+        )
+        fake_llm = FakeLLMPort(responses=[pick, judge, pick, judge, pick, judge])
+        orch = Orchestrator(
+            llm=fake_llm,
+            anonymizer=FakeAnonymizer(),
+            settings=settings,
+            llm_timeout_seconds=LLM_TIMEOUT,
+            max_total_tokens=MAX_TOKENS,
+        )
+
+        result = await orch.assign_codes(request, _future_deadline())
+
+        assigned = result.coded_feedback_records[0].assigned_codes[0]
+        assert assigned.type_label == "Type A"
+        assert assigned.category_label == "Cat A1"
+        assert assigned.code_label == "Code A1.1"


### PR DESCRIPTION
> [!WARNING]
> **Breaking API change — the `/v1/assign-codes` response shape changes.**
> - **`code_id` is removed** from each assigned code. It only ever mirrored `code_label` (the inbound `coding_levels` nodes carry names, not stable ids), so it carried no information.
> - **Two fields are added** to each assigned code: `type_label` (level 1) and `category_label` (level 2), alongside the existing `code_label` (level 3 leaf).
>
> Any EspoCRM script or client parsing the assign-codes response must stop reading `code_id` and read the three `*_label` fields. EspoCRM maps the upper two levels back to its `CCodingLevel1/2` records **by name**.

Closes #149.

## What & why

The `assign-codes` endpoint previously returned only the leaf code per assignment. Issue #149 asks it to return **all three coding levels** so EspoCRM can map an assignment back to `CCodingLevel1/2/3`.

Since `ApiCodingNode` carries only names (no ids), there are no stable Type/Category ids to return — so the assignment is made self-describing by **name** instead:

- `type_label` — Type level (1)
- `category_label` — Category level (2)
- `code_label` — Code level (3, leaf)

`code_id` is dropped because it was a duplicate of `code_label`.

## Changes

- **Domain** (`AssignedCodeModel`): add `type_label` / `category_label`, drop `code_id`.
- **Orchestrator**: thread the Type and Category names (already in scope in the pick loop) through `_ScoredCode` into the assignment.
- **API** (`ApiAssignedCode` + route): expose the two label fields, drop `code_id`, add OpenAPI field descriptions; expand the route docstring with response semantics.
- **Docs** (`ubiquitous_language.md`): define *Coding type* / *Coding category* / *Code* inline by the *Coding framework* entry.

## Tests

- Service-level (`tests/services/test_orchestrator.py`): drives the real `assign_codes` over a 3-level framework and asserts the assignment carries all three labels.
- API-level (`tests/api/test_routes.py`): asserts the response exposes the three labels and **no longer** includes `code_id`.

Full suite: **426 passed**; `make lint` clean (3 hexagonal contracts kept); `make docs` builds.
