### PR TITLE
fix: formalise feedback record metadata contract

### DIFF
--- a/docs/architecture/05-data-model.md
+++ b/docs/architecture/05-data-model.md
@@ -19,6 +19,32 @@ Domain entities live in {py:mod}`qfa.domain.models`, with usage-tracking entitie
 | {py:class}`~qfa.domain.usage_models.LLMCallRecord` | One LLM call's worth of tracking data — written by {py:class}`~qfa.adapters.tracking_llm.TrackingLLMAdapter`. |
 | {py:class}`~qfa.domain.usage_models.UsageMetrics`, {py:class}`~qfa.domain.usage_models.OperationStats`, {py:class}`~qfa.domain.usage_models.TenantUsageStats`, {py:class}`~qfa.domain.usage_models.TenantStats`, {py:class}`~qfa.domain.usage_models.OperationUsageStats`, {py:class}`~qfa.domain.usage_models.DistributionStats` | Aggregate views returned by `/v1/usage`, `/v1/usage/all/by-tenant`, and `/v1/usage/all/by-operation`. `TenantUsageStats` / `OperationStats` carry the tenant-top-level hierarchy with per-operation nested; `OperationUsageStats` / `TenantStats` carry the inverse operation-top-level hierarchy with per-tenant nested. Every block exposes per-invocation top-level fields plus a per-LLM-call `llm_call_stats`. `UsageMetrics` is the shared leaf class. `DistributionStats` is the shared distribution shape (avg/min/max/p5/p95/total) used for `call_duration`, `input_tokens`, and `output_tokens`. |
 
+## Feedback record metadata contract
+
+Each {py:class}`~qfa.domain.models.FeedbackRecordModel` carries a free-form
+`metadata` dict (`dict[str, str | int | float | bool]`). The pipeline reads two
+fields from it by convention; the rest pass through unchanged.
+
+The documented contract is {py:class}`~qfa.domain.models.FeedbackRecordMetadata`
+(in `qfa.domain.models`). It is not used as the type of the `metadata` field —
+callers may include arbitrary extra keys — but it names the two fields the
+pipeline consumes:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `created` | `str` (ISO-8601 date) | Time-bucket for the coding-trend table and within-chunk chronological sort. |
+| `codes` | `str` (comma-separated labels) | Code axis of the coding-trend table. |
+
+Both fields are optional. A record missing `created` is excluded from the trend
+table but still analysed. A record missing `codes` contributes no cells to the
+trend table but is otherwise unaffected.
+
+The field names (`created`, `codes`) are the **single source of truth** defined
+by `METADATA_DATE_FIELD` and `METADATA_CODE_FIELD` in `qfa.settings`. The
+settings `ANALYZE_CODING_TREND_DATE_FIELD` and `ANALYZE_CODING_TREND_CODE_FIELDS`
+default to those constants, so the corpus generator, the pipeline, and the
+settings defaults all reference the same values and cannot drift apart.
+
 ## Persistence — `llm_calls`
 
 When `DB_TRACK_USAGE=true`, every LLM call appends one row to the `llm_calls` table. The schema lives in `qfa.adapters.db` and is managed by Alembic migrations under `migrations/`.

--- a/docs/architecture/05-data-model.md
+++ b/docs/architecture/05-data-model.md
@@ -25,11 +25,6 @@ Each {py:class}`~qfa.domain.models.FeedbackRecordModel` carries a free-form
 `metadata` dict (`dict[str, str | int | float | bool]`). The pipeline reads two
 fields from it by convention; the rest pass through unchanged.
 
-The documented contract is {py:class}`~qfa.domain.models.FeedbackRecordMetadata`
-(in `qfa.domain.models`). It is not used as the type of the `metadata` field —
-callers may include arbitrary extra keys — but it names the two fields the
-pipeline consumes:
-
 | Field | Type | Purpose |
 |---|---|---|
 | `created` | `str` (ISO-8601 date) | Time-bucket for the coding-trend table and within-chunk chronological sort. |

--- a/scripts/generate_corpus.py
+++ b/scripts/generate_corpus.py
@@ -61,6 +61,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import yaml
 
+from qfa.settings import METADATA_CODE_FIELD, METADATA_DATE_FIELD
+
 logger = logging.getLogger("generate_corpus")
 
 # --- Timeline -----------------------------------------------------------------
@@ -197,7 +199,7 @@ PATTERN_PRIORITY: list[str] = [
 
 def _record_leaves(record: dict[str, Any]) -> list[str]:
     """Return the list of leaf code strings carried by a record."""
-    raw = record.get("metadata", {}).get("codes", "") or ""
+    raw = record.get("metadata", {}).get(METADATA_CODE_FIELD, "") or ""
     return [c.strip() for c in raw.split(",") if c.strip()]
 
 
@@ -380,7 +382,7 @@ def assign_dates(
             )
         for idx, date in zip(indices, dates, strict=True):
             iso = date.isoformat()
-            records[idx]["metadata"]["created"] = iso
+            records[idx]["metadata"][METADATA_DATE_FIELD] = iso
             records[idx]["metadata"]["year"] = date.year
 
     return dict(by_pattern)
@@ -495,7 +497,9 @@ def make_plot(
                 for idx in indices:
                     if leaf not in _record_leaves(records[idx]):
                         continue
-                    d = dt.date.fromisoformat(records[idx]["metadata"]["created"])
+                    d = dt.date.fromisoformat(
+                        records[idx]["metadata"][METADATA_DATE_FIELD]
+                    )
                     m = (d.year - START.year) * 12 + (d.month - START.month)
                     counts[m] += 1
                 ax.bar(
@@ -510,7 +514,7 @@ def make_plot(
 
             totals = np.zeros(N_MONTHS, dtype=int)
             for idx in indices:
-                d = dt.date.fromisoformat(records[idx]["metadata"]["created"])
+                d = dt.date.fromisoformat(records[idx]["metadata"][METADATA_DATE_FIELD])
                 m = (d.year - START.year) * 12 + (d.month - START.month)
                 totals[m] += 1
             ax.bar(
@@ -525,7 +529,7 @@ def make_plot(
             ax.legend(loc="upper left", fontsize=7, ncols=2, frameon=False)
         else:
             dates = [
-                dt.date.fromisoformat(records[i]["metadata"]["created"])
+                dt.date.fromisoformat(records[i]["metadata"][METADATA_DATE_FIELD])
                 for i in indices
             ]
             days = (
@@ -775,7 +779,7 @@ def _sample_metadata(
         "source": rng.choices(sources, weights=source_weights, k=1)[0],
         "year": START.year,
         "sensitive": sensitive,
-        "codes": leaf.code_id,
+        METADATA_CODE_FIELD: leaf.code_id,
     }
 
 
@@ -843,7 +847,7 @@ def gen_specs(
         leaf: pattern for pattern, leaves_in in carriers.items() for leaf in leaves_in
     }
     for record in records:
-        cid = record["metadata"]["codes"]
+        cid = record["metadata"][METADATA_CODE_FIELD]
         leaf = leaf_by_id[cid]
         record["_context"] = {
             "code_name": leaf.name,
@@ -935,7 +939,7 @@ def merge(
         out_records.append({"id": spec["id"], "text": text, "metadata": metadata})
 
         role = spec.get("_context", {}).get("trend_role", "baseline")
-        cid = spec["metadata"]["codes"].split(",")[0].strip()
+        cid = spec["metadata"][METADATA_CODE_FIELD].split(",")[0].strip()
         if role != "baseline" and cid not in carriers[role]:
             carriers[role].append(cid)
         by_pattern[role].append(i)

--- a/src/qfa/domain/models.py
+++ b/src/qfa/domain/models.py
@@ -19,20 +19,6 @@ from qfa.domain.clustering_models import CodingTrendTable, TrendPeriod
 from qfa.domain.sensitivity_types import SensitivityType
 
 
-class FeedbackRecordMetadata(BaseModel):
-    """Metadata fields consumed by the analysis pipeline.
-
-    All fields are optional. Missing fields degrade gracefully
-    (no trend table, no date sorting) but emit a WARNING.
-    Extra fields (region, year, etc.) are passed through unchanged.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    created: str | None = None  # ISO-8601 date — trend table + chunk sorting
-    codes: str | None = None  # comma-separated labels — trend table code axis
-
-
 class FeedbackRecordModel(BaseModel):
     """A single feedback record submitted for analysis."""
 
@@ -46,11 +32,7 @@ class FeedbackRecordModel(BaseModel):
     )
     metadata: dict[str, str | int | float | bool] = Field(
         default_factory=dict,
-        description=(
-            "Metadata key-value pairs for the feedback record. "
-            "The pipeline consumes two fields by convention — see "
-            "``FeedbackRecordMetadata`` for the documented contract."
-        ),
+        description="Metadata key-value pairs for the feedback record.",
     )
 
 

--- a/src/qfa/domain/models.py
+++ b/src/qfa/domain/models.py
@@ -19,6 +19,20 @@ from qfa.domain.clustering_models import CodingTrendTable, TrendPeriod
 from qfa.domain.sensitivity_types import SensitivityType
 
 
+class FeedbackRecordMetadata(BaseModel):
+    """Metadata fields consumed by the analysis pipeline.
+
+    All fields are optional. Missing fields degrade gracefully
+    (no trend table, no date sorting) but emit a WARNING.
+    Extra fields (region, year, etc.) are passed through unchanged.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    created: str | None = None  # ISO-8601 date — trend table + chunk sorting
+    codes: str | None = None  # comma-separated labels — trend table code axis
+
+
 class FeedbackRecordModel(BaseModel):
     """A single feedback record submitted for analysis."""
 
@@ -32,7 +46,11 @@ class FeedbackRecordModel(BaseModel):
     )
     metadata: dict[str, str | int | float | bool] = Field(
         default_factory=dict,
-        description="Optional metadata key-value pairs associated with the feedback record.",
+        description=(
+            "Metadata key-value pairs for the feedback record. "
+            "The pipeline consumes two fields by convention — see "
+            "``FeedbackRecordMetadata`` for the documented contract."
+        ),
     )
 
 

--- a/src/qfa/services/coding_trends.py
+++ b/src/qfa/services/coding_trends.py
@@ -13,6 +13,7 @@ where 2024-12-30 would otherwise collide with truly-January-2024
 records.
 """
 
+import logging
 from collections import Counter
 from collections.abc import Sequence
 from datetime import date
@@ -23,6 +24,9 @@ from qfa.domain.clustering_models import (
     TrendPeriod,
 )
 from qfa.domain.models import FeedbackRecordModel
+
+logger = logging.getLogger(__name__)
+
 
 # Re-exported here for back-compat with call sites that import the alias
 # from ``qfa.services.coding_trends`` (where the bucketing logic lives).
@@ -161,8 +165,21 @@ def build_coding_trend_table(
             counter[(code, bucket)] += 1
 
     if not periods:
+        logger.warning(
+            "coding_trends: date field %r matched 0 of %d record(s) — "
+            "check if the field name is exactly the same and if the values are parseable dates",
+            date_field,
+            len(records),
+        )
         return None
 
+    if not counter:
+        logger.warning(
+            "coding_trends: code fields %r matched 0 labels across %d dated record(s) — "
+            "check code fields names and check if the values are comma-separated strings",
+            list(code_fields),
+            len(periods),
+        )
     cells = tuple(
         CodingTrendCell(code=code, period=bucket, count=count)
         for (code, bucket), count in sorted(counter.items())

--- a/src/qfa/services/prompts.py
+++ b/src/qfa/services/prompts.py
@@ -166,34 +166,13 @@ def build_analyze_user_message(
     here — it is trusted config, not part of the untrusted record envelope
     (#161).
     """
-    record_blocks: list[str] = []
-    for record in feedback_records:
-        rec_id_attr = _xml_quoteattr(record.id)
-        rec_text = escape_for_tag_envelope(record.content)
-        metadata_lines = "\n".join(
-            f"      {escape_for_tag_envelope(str(k))}={escape_for_tag_envelope(str(v))}"
-            for k, v in record.metadata.items()
-        )
-        metadata_block = (
-            f"    <metadata>\n{metadata_lines}\n    </metadata>\n"
-            if metadata_lines
-            else ""
-        )
-        record_blocks.append(
-            f"  <feedback_record id={rec_id_attr}>\n"
-            f"    <text>{rec_text}</text>\n"
-            f"{metadata_block}"
-            f"  </feedback_record>"
-        )
-    records_xml = "\n".join(record_blocks)
+    feedbackrecords_xml = build_feedback_records_envelope(feedback_records)
     return (
         f"<analyst_instruction>\n"
         f"{escape_for_tag_envelope(analyst_prompt)}\n"
         f"</analyst_instruction>\n"
         f"\n"
-        f"<feedback_records>\n"
-        f"{records_xml}\n"
-        f"</feedback_records>"
+        f"{feedbackrecords_xml}\n"
     )
 
 
@@ -206,3 +185,35 @@ def build_analyze_judge_system_message(
         analyst_prompt=analyst_prompt,
         analysis=analysis,
     )
+
+
+def build_feedback_record_envelope(
+    feedback_record: FeedbackRecordModel,
+) -> str:
+    """Build a single <feedback_record> envelope for a record."""
+    rec_id_attr = _xml_quoteattr(feedback_record.id)
+    rec_text = escape_for_tag_envelope(feedback_record.content)
+    metadata_lines = "\n".join(
+        f"      {escape_for_tag_envelope(str(k))}={escape_for_tag_envelope(str(v))}"
+        for k, v in feedback_record.metadata.items()
+    )
+    metadata_block = (
+        f"    <metadata>\n{metadata_lines}\n    </metadata>\n" if metadata_lines else ""
+    )
+    return (
+        f"  <feedback_record id={rec_id_attr}>\n"
+        f"    <text>{rec_text}</text>\n"
+        f"{metadata_block}"
+        f"  </feedback_record>"
+    )
+
+
+def build_feedback_records_envelope(
+    feedback_records: tuple[FeedbackRecordModel, ...],
+) -> str:
+    """Build a <feedback_records> envelope for a sequence of records."""
+    record_blocks: list[str] = [
+        build_feedback_record_envelope(record) for record in feedback_records
+    ]
+    records_xml = "\n".join(record_blocks)
+    return f"<feedback_records>\n{records_xml}\n</feedback_records>"

--- a/src/qfa/settings.py
+++ b/src/qfa/settings.py
@@ -25,6 +25,12 @@ Single source of truth shared by ``EmbeddingSettings.batch_size`` and the
 default and the library default cannot silently drift apart.
 """
 
+# Single source of truth for metadata field names consumed by the pipeline.
+# AnalyzeSettings defaults and the corpus generator both reference these
+# so they cannot silently drift apart.
+METADATA_DATE_FIELD = "created"
+METADATA_CODE_FIELD = "codes"
+
 
 class LogSettings(BaseSettings):
     """Define settings for the logger."""
@@ -224,11 +230,11 @@ class AnalyzeSettings(BaseSettings):
         ),
     )
     coding_trend_date_field: str = Field(
-        default="created",
+        default=METADATA_DATE_FIELD,
         description="Metadata key holding the record date for the coding-trend table.",
     )
     coding_trend_code_fields: list[str] = Field(
-        default_factory=lambda: ["codes"],
+        default_factory=lambda: [METADATA_CODE_FIELD],
         description="Metadata keys holding coding labels (comma-separated strings).",
     )
     default_coding_trend_period: TrendPeriod = Field(

--- a/tests/services/test_clustering.py
+++ b/tests/services/test_clustering.py
@@ -9,6 +9,7 @@ These are pure, deterministic and tested with hand-built vectors (no model).
 
 from qfa.domain.models import FeedbackRecordModel
 from qfa.services.clustering import _split_to_budget, cluster_records
+from qfa.settings import METADATA_DATE_FIELD
 
 
 def _record(
@@ -16,7 +17,7 @@ def _record(
 ) -> FeedbackRecordModel:
     metadata: dict[str, str | int | float] = {}
     if created is not None:
-        metadata["created"] = created
+        metadata[METADATA_DATE_FIELD] = created
     return FeedbackRecordModel(id=rec_id, content=content, metadata=metadata)
 
 
@@ -210,10 +211,10 @@ def test_records_are_sorted_by_date_within_each_chunk() -> None:
         min_cluster_size=2,
         max_total_tokens=100_000,
         chars_per_token=4,
-        date_field="created",
+        date_field=METADATA_DATE_FIELD,
     )
     for chunk in chunks:
-        seen = [r.metadata["created"] for r in chunk.records]
+        seen = [r.metadata[METADATA_DATE_FIELD] for r in chunk.records]
         assert seen == sorted(seen), f"chunk not in date order: {seen}"
 
 
@@ -238,7 +239,7 @@ def test_records_without_a_parseable_date_sort_last_and_stably() -> None:
         min_cluster_size=2,
         max_total_tokens=100_000,
         chars_per_token=4,
-        date_field="created",
+        date_field=METADATA_DATE_FIELD,
     )
     # All records land in one chunk (tight cluster, well under budget).
     assert len(chunks) == 1

--- a/tests/services/test_coding_trends.py
+++ b/tests/services/test_coding_trends.py
@@ -12,13 +12,14 @@ from qfa.services.coding_trends import (
     build_coding_trend_table,
     render_coding_trend_table,
 )
+from qfa.settings import METADATA_CODE_FIELD, METADATA_DATE_FIELD
 
 
 def _record(rec_id: str, created: str, codes: str) -> FeedbackRecordModel:
     return FeedbackRecordModel(
         id=rec_id,
         content="some feedback",
-        metadata={"created": created, "codes": codes},
+        metadata={METADATA_DATE_FIELD: created, METADATA_CODE_FIELD: codes},
     )
 
 
@@ -67,7 +68,7 @@ def test_counts_codes_per_week_period_default() -> None:
         _record("r3", "2024-01-08T10:00:00Z", "Water"),
     )
     table = build_coding_trend_table(
-        records, date_field="created", code_fields=("codes",)
+        records, date_field=METADATA_DATE_FIELD, code_fields=(METADATA_CODE_FIELD,)
     )
     assert table is not None
     assert table.periods == ("2024-W01", "2024-W02")
@@ -89,7 +90,10 @@ def test_counts_codes_per_day_period() -> None:
         _record("r3", "2024-01-06T08:00:00Z", "Water"),
     )
     table = build_coding_trend_table(
-        records, date_field="created", code_fields=("codes",), period="day"
+        records,
+        date_field=METADATA_DATE_FIELD,
+        code_fields=(METADATA_CODE_FIELD,),
+        period="day",
     )
     assert table is not None
     counts = {(c.code, c.period): c.count for c in table.cells}
@@ -102,9 +106,13 @@ def test_returns_none_when_date_field_absent() -> None:
 
     Why: the spec mandates best-effort; a missing field must never raise.
     """
-    records = (FeedbackRecordModel(id="r1", content="x", metadata={"codes": "Water"}),)
+    records = (
+        FeedbackRecordModel(
+            id="r1", content="x", metadata={METADATA_CODE_FIELD: "Water"}
+        ),
+    )
     table = build_coding_trend_table(
-        records, date_field="created", code_fields=("codes",)
+        records, date_field=METADATA_DATE_FIELD, code_fields=(METADATA_CODE_FIELD,)
     )
     assert table is None
 
@@ -118,11 +126,14 @@ def test_records_without_codes_are_skipped_not_errored() -> None:
     records = (
         _record("r1", "2024-01-05T10:00:00Z", "Water"),
         FeedbackRecordModel(
-            id="r2", content="x", metadata={"created": "2024-01-06T10:00:00Z"}
+            id="r2", content="x", metadata={METADATA_DATE_FIELD: "2024-01-06T10:00:00Z"}
         ),
     )
     table = build_coding_trend_table(
-        records, date_field="created", code_fields=("codes",), period="month"
+        records,
+        date_field=METADATA_DATE_FIELD,
+        code_fields=(METADATA_CODE_FIELD,),
+        period="month",
     )
     assert table is not None
     counts = {(c.code, c.period): c.count for c in table.cells}

--- a/tests/services/test_orchestrator.py
+++ b/tests/services/test_orchestrator.py
@@ -25,7 +25,7 @@ from qfa.domain.models import (
 from qfa.domain.ports import AnonymizationPort, LLMPort
 from qfa.domain.sensitivity_types import SensitivityType
 from qfa.services.orchestrator import Orchestrator
-from qfa.settings import OrchestratorSettings
+from qfa.settings import METADATA_CODE_FIELD, METADATA_DATE_FIELD, OrchestratorSettings
 
 TENANT_ID = "tenant-42"
 LLM_TIMEOUT = 30.0
@@ -1032,12 +1032,18 @@ class TestAnalyzeHappyPath:
             _make_feedback_record(
                 doc_id="r1",
                 content="water access was limited",
-                metadata={"created": "2024-01-05T10:00:00Z", "codes": "Water"},
+                metadata={
+                    METADATA_DATE_FIELD: "2024-01-05T10:00:00Z",
+                    METADATA_CODE_FIELD: "Water",
+                },
             ),
             _make_feedback_record(
                 doc_id="r2",
                 content="health clinic medicine",
-                metadata={"created": "2024-02-02T10:00:00Z", "codes": "Health"},
+                metadata={
+                    METADATA_DATE_FIELD: "2024-02-02T10:00:00Z",
+                    METADATA_CODE_FIELD: "Health",
+                },
             ),
         )
         request = _make_request(feedback_records=records).model_copy(

--- a/tests/services/test_orchestrator_hierarchical.py
+++ b/tests/services/test_orchestrator_hierarchical.py
@@ -21,7 +21,12 @@ from qfa.domain.models import (
 )
 from qfa.services.orchestrator import AnalyzeJudgeResult, Orchestrator
 from qfa.services.prompts import ANALYZE_GUARDRAILS_PROMPT
-from qfa.settings import AnalyzeSettings, OrchestratorSettings
+from qfa.settings import (
+    METADATA_CODE_FIELD,
+    METADATA_DATE_FIELD,
+    AnalyzeSettings,
+    OrchestratorSettings,
+)
 
 TENANT_ID = "tenant-42"
 LLM_TIMEOUT = 30.0
@@ -105,7 +110,10 @@ def _records(n: int, text: str, prefix: str) -> tuple[FeedbackRecordModel, ...]:
         FeedbackRecordModel(
             id=f"{prefix}{i}",
             content=text,
-            metadata={"created": "2024-01-05T00:00:00Z", "codes": "Water"},
+            metadata={
+                METADATA_DATE_FIELD: "2024-01-05T00:00:00Z",
+                METADATA_CODE_FIELD: "Water",
+            },
         )
         for i in range(n)
     )
@@ -213,7 +221,10 @@ async def test_anonymization_happens_before_any_llm_or_embed_call():
         FeedbackRecordModel(
             id="r1",
             content="Jane reported water shortages " * 5,
-            metadata={"created": "2024-01-05T00:00:00Z", "codes": "Water"},
+            metadata={
+                METADATA_DATE_FIELD: "2024-01-05T00:00:00Z",
+                METADATA_CODE_FIELD: "Water",
+            },
         ),
         *_records(3, "water access " * 5, "w"),
     )

--- a/tests/test_analyze_corpus.py
+++ b/tests/test_analyze_corpus.py
@@ -16,6 +16,7 @@ import pytest
 import yaml
 
 from qfa.domain.models import FeedbackRecordModel
+from qfa.settings import METADATA_CODE_FIELD
 
 FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
 CORPUS_PATH = FIXTURES / "analyze_corpus.yaml"
@@ -81,7 +82,9 @@ class TestAnalyzeCorpus:
         unknown: dict[str, list[str]] = {}
         for item in corpus:
             code_ids = [
-                c.strip() for c in item["metadata"]["codes"].split(",") if c.strip()
+                c.strip()
+                for c in item["metadata"][METADATA_CODE_FIELD].split(",")
+                if c.strip()
             ]
             missing = [c for c in code_ids if c not in framework]
             if missing:
@@ -97,7 +100,9 @@ class TestAnalyzeCorpus:
         mismatches: list[str] = []
         for item in corpus:
             md = item["metadata"]
-            code_ids = [c.strip() for c in md["codes"].split(",") if c.strip()]
+            code_ids = [
+                c.strip() for c in md[METADATA_CODE_FIELD].split(",") if c.strip()
+            ]
             code_types = {framework[c]["feedback_type"] for c in code_ids}
             if code_types != {md["feedback_type"]}:
                 mismatches.append(
@@ -123,7 +128,8 @@ class TestAnalyzeCorpus:
         offenders = [
             item["id"]
             for item in corpus
-            if ", " in item["metadata"]["codes"] or " ," in item["metadata"]["codes"]
+            if ", " in item["metadata"][METADATA_CODE_FIELD]
+            or " ," in item["metadata"][METADATA_CODE_FIELD]
         ]
         assert not offenders, f"codes string has whitespace around comma: {offenders}"
 
@@ -134,6 +140,8 @@ class TestAnalyzeCorpus:
         empty = [
             item["id"]
             for item in corpus
-            if not [c for c in item["metadata"]["codes"].split(",") if c.strip()]
+            if not [
+                c for c in item["metadata"][METADATA_CODE_FIELD].split(",") if c.strip()
+            ]
         ]
         assert not empty, f"records with empty codes: {empty}"

--- a/tests/test_large_corpus.py
+++ b/tests/test_large_corpus.py
@@ -14,6 +14,7 @@ import yaml
 from qfa.domain.models import FeedbackRecordModel
 from qfa.services.clustering import cluster_records
 from qfa.services.coding_trends import build_coding_trend_table
+from qfa.settings import METADATA_CODE_FIELD, METADATA_DATE_FIELD
 
 FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
 CORPUS_PATH = FIXTURES / "large_corpus.yaml"
@@ -104,15 +105,18 @@ def test_coding_trend_table_counts_match_corpus() -> None:
     # default granularity is ``week``, but the fixture isn't aligned to
     # ISO weeks.
     table = build_coding_trend_table(
-        records, date_field="created", code_fields=("codes",), period="month"
+        records,
+        date_field=METADATA_DATE_FIELD,
+        code_fields=(METADATA_CODE_FIELD,),
+        period="month",
     )
     assert table is not None
     # Hand count of one known (code, period) pair from the fixture.
     expected = sum(
         1
         for item in corpus
-        if "Water" in item["metadata"]["codes"].split(",")
-        and item["metadata"]["created"].startswith("2024-01")
+        if "Water" in item["metadata"][METADATA_CODE_FIELD].split(",")
+        and item["metadata"][METADATA_DATE_FIELD].startswith("2024-01")
     )
     got = next(
         (c.count for c in table.cells if c.code == "Water" and c.period == "2024-01"),


### PR DESCRIPTION
Non-AI comment: "I am still understanding the structure of the code, so please be hars on me if anything is in the wrong place" ;) 

Closes #143 

## Summary

- Add `METADATA_DATE_FIELD` and `METADATA_CODE_FIELD` constants to `settings.py` as the single source of truth for pipeline-consumed metadata field names, so the corpus generator, pipeline, and settings defaults cannot drift apart again
- Add `FeedbackRecordMetadata` to `qfa.domain.models` as a documented schema of the two fields the pipeline consumes (`created`, `codes`), their types, and optional status
- Emit a `WARNING` in `build_coding_trend_table` when the configured date field or code fields match zero records, so a field-name mismatch surfaces in logs immediately instead of silently returning an empty trend table
- Document the metadata contract in `docs/architecture/05-data-model.md`

## Test plan

- [ ] `uv run pytest tests/services/test_coding_trends.py tests/services/test_clustering.py tests/test_large_corpus.py tests/test_analyze_corpus.py tests/services/test_orchestrator.py tests/services/test_orchestrator_hierarchical.py -q`
- [ ] Confirm a WARNING log appears when `date_field` matches no records