### PR TITLE
docs(operations): add how-to runbook for forcing Key Vault reference refresh

### DIFF
--- a/docs/operations/auth-management.md
+++ b/docs/operations/auth-management.md
@@ -92,7 +92,7 @@ Key rotation steps:
 3. Wait until you've verified the tenant is using the new key (look for the new `key_id` in logs).
 4. `--replace <tenant>` with their now-confirmed new key, or `--remove <tenant>` plus `--add` if you want a clean cut.
 
-App Service picks up Key Vault changes within a few minutes. To force an immediate refresh, see [Operational how-tos § Force refresh of changed Key Vault values](how-to.md#force-refresh-of-changed-key-vault-values).
+App Service can take up to ~24 hours to pick up a rotated Key Vault value on its own — it caches references and refetches them only about once a day. To force an immediate refresh, see [Operational how-tos § Force refresh of changed Key Vault values](how-to.md#force-refresh-of-changed-key-vault-values).
 
 ## Local dev
 

--- a/docs/operations/auth-management.md
+++ b/docs/operations/auth-management.md
@@ -92,7 +92,7 @@ Key rotation steps:
 3. Wait until you've verified the tenant is using the new key (look for the new `key_id` in logs).
 4. `--replace <tenant>` with their now-confirmed new key, or `--remove <tenant>` plus `--add` if you want a clean cut.
 
-App Service picks up Key Vault changes within a few minutes. To force an immediate refresh, restart the App Service from the Azure portal.
+App Service picks up Key Vault changes within a few minutes. To force an immediate refresh, see [Operational how-tos § Force refresh of changed Key Vault values](how-to.md#force-refresh-of-changed-key-vault-values).
 
 ## Local dev
 

--- a/docs/operations/how-to.md
+++ b/docs/operations/how-to.md
@@ -1,0 +1,67 @@
+# Operational How-Tos
+
+Short, copy-pasteable runbooks for recurring operational tasks. Each entry is
+self-contained; pick the one you need.
+
+## Environment naming
+
+The resource group and App Service names are **not** symmetric across
+environments, so double-check both before running a command against production.
+
+| Environment | App Service (`-n`) | Resource group (`-g`) | Key Vault |
+|---|---|---|---|
+| dev | `qfa-dev-backend` | `qualitative-feedback-analysis-xomnia` | `qfa-dev-keyvault` |
+| staging | `qfa-staging-backend` | `qualitative-feedback-analysis-staging` | `qfa-staging-keyvault` |
+| prd | `qfa-prd-backend` | `qualitative-feedback-analysis-production` | `qfa-prd-keyvault` |
+
+Note the mismatch: the App Service name uses `prd`, but its resource group is
+`…-production`; and the dev resource group is `…-xomnia`, not `…-dev`.
+
+## Force refresh of changed Key Vault values
+
+Secrets reach the App Service as
+[Key Vault references](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references)
+(e.g. `@Microsoft.KeyVault(SecretUri=…)`) in the app settings. App Service
+**caches** the resolved values, so a freshly rotated secret does not take effect
+immediately — the platform refreshes the cache periodically (within a few
+minutes to ~24h), and always re-reads every reference on startup.
+
+To force an immediate re-read, recycle the app. Any app-setting change triggers
+a worker restart, so writing a throwaway setting does the job:
+
+```bash
+# Substitute -n / -g for your environment from the table above.
+az webapp config appsettings set \
+  -n qfa-prd-backend -g qualitative-feedback-analysis-production \
+  --settings KV_REFRESH_TOUCH=$(date +%s)
+```
+
+`KV_REFRESH_TOUCH` is an arbitrary, unused setting; the `$(date +%s)` value just
+guarantees it changes each run so the save always recycles the app. The app
+re-resolves **all** Key Vault references on the restart that follows.
+
+Equivalent alternatives:
+
+- **Restart only** (leaves no throwaway setting behind):
+  ```bash
+  az webapp restart -n qfa-prd-backend -g qualitative-feedback-analysis-production
+  ```
+- **Portal**: open the App Service → **Restart**, or add/save any setting under
+  **Settings → Environment variables**. The Portal also shows a per-setting
+  resolution status, which is the quickest way to confirm a reference resolved
+  rather than silently keeping a stale value.
+
+> **Tip — token staleness on the CLI.** If `az` returns `AuthorizationFailed`
+> for `Microsoft.Web/sites/config/list/action` right after a role was granted
+> (or a PIM role activated), your cached access token predates the grant. Run
+> `az account clear && az login` to mint a fresh token, or use the Portal, which
+> re-authenticates per action.
+
+## Versionless vs. pinned secret references
+
+If a Key Vault reference's `SecretUri` ends with a version GUID
+(`…/secrets/<name>/<version>`), App Service is pinned to that exact version and
+will **never** pick up a rotated secret — even after a restart — until the app
+setting itself is changed. Use a **versionless** URI (trailing `/`, no version)
+so rotations are picked up by the periodic refresh or a recycle. The
+Terraform-managed references in `app_service.tf` are versionless by design.

--- a/docs/operations/how-to.md
+++ b/docs/operations/how-to.md
@@ -23,11 +23,13 @@ Secrets reach the App Service as
 [Key Vault references](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references)
 (e.g. `@Microsoft.KeyVault(SecretUri=…)`) in the app settings. App Service
 **caches** the resolved values, so a freshly rotated secret does not take effect
-immediately — the platform refreshes the cache periodically (within a few
-minutes to ~24h), and always re-reads every reference on startup.
+immediately: for a versionless reference the platform refetches the cache on its
+own only [about every 24 hours](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references#understand-rotation),
+so a rotation can take up to a day to land unless you force it.
 
-To force an immediate re-read, recycle the app. Any app-setting change triggers
-a worker restart, so writing a throwaway setting does the job:
+To force an immediate re-read, change any app setting. [Per Microsoft](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references#understand-rotation),
+"any configuration change to the app causes an app restart and an immediate
+refetch of all referenced secrets" — so writing a throwaway setting does the job:
 
 ```bash
 # Substitute -n / -g for your environment from the table above.
@@ -37,19 +39,27 @@ az webapp config appsettings set \
 ```
 
 `KV_REFRESH_TOUCH` is an arbitrary, unused setting; the `$(date +%s)` value just
-guarantees it changes each run so the save always recycles the app. The app
-re-resolves **all** Key Vault references on the restart that follows.
+guarantees it changes each run, so every save is a real configuration change and
+therefore forces the refetch of **all** references.
 
-Equivalent alternatives:
+Alternatives:
 
-- **Restart only** (leaves no throwaway setting behind):
+- **Refresh API** — forces re-resolution with no throwaway setting *and* no
+  restart, by [POSTing to the `configreferences` refresh endpoint](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references#understand-rotation):
   ```bash
-  az webapp restart -n qfa-prd-backend -g qualitative-feedback-analysis-production
+  az rest --method post --url \
+    "https://management.azure.com/subscriptions/<sub-id>/resourceGroups/qualitative-feedback-analysis-production/providers/Microsoft.Web/sites/qfa-prd-backend/config/configreferences/appsettings/refresh?api-version=2022-03-01"
   ```
-- **Portal**: open the App Service → **Restart**, or add/save any setting under
-  **Settings → Environment variables**. The Portal also shows a per-setting
-  resolution status, which is the quickest way to confirm a reference resolved
-  rather than silently keeping a stale value.
+- **Portal**: open the App Service → **Settings → Environment variables** and
+  add/save any setting. The Portal also shows a per-setting resolution status,
+  which is the quickest way to confirm a reference resolved rather than silently
+  keeping a stale value.
+
+> **Don't rely on a bare restart.** `az webapp restart` (or Portal → **Restart**)
+> *without* a configuration change is **not** documented to re-read Key Vault
+> references, and in practice it often keeps serving the cached values. Force a
+> refresh with a configuration change or the refresh API above — not a restart
+> alone.
 
 > **Tip — token staleness on the CLI.** If `az` returns `AuthorizationFailed`
 > for `Microsoft.Web/sites/config/list/action` right after a role was granted
@@ -61,7 +71,9 @@ Equivalent alternatives:
 
 If a Key Vault reference's `SecretUri` ends with a version GUID
 (`…/secrets/<name>/<version>`), App Service is pinned to that exact version and
-will **never** pick up a rotated secret — even after a restart — until the app
-setting itself is changed. Use a **versionless** URI (trailing `/`, no version)
-so rotations are picked up by the periodic refresh or a recycle. The
-Terraform-managed references in `app_service.tf` are versionless by design.
+will **never** pick up a rotated secret — even after a restart or a
+configuration change — until the app setting itself is repointed. Use a
+**versionless** URI (no `/<version>` suffix, e.g. `…/secrets/<name>`) so
+rotations are picked up by the periodic (~24 h) refresh, or immediately via a
+configuration change / the refresh API above. The Terraform-managed references
+in `app_service.tf` are versionless by design.

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -11,6 +11,7 @@ Running, deploying, and observing the service.
 | [API key management](auth-management.md) | Adding, rotating, and revoking API keys |
 | [Settings reference](settings-reference.md) | Every environment variable the app reads |
 | [Observability](observability.md) | What gets logged, request tracing, usage queries |
+| [Operational how-tos](how-to.md) | Copy-pasteable runbooks (e.g. force-refresh changed Key Vault values) |
 
 For first-time setup, follow [Infrastructure bootstrap](bootstrap.md) → [Set up a new environment](setup-new-env.md) in that order.
 
@@ -24,4 +25,5 @@ setup-new-env
 auth-management
 settings-reference
 observability
+how-to
 ```


### PR DESCRIPTION
## What

Adds a new operations runbook page, **Operational How-Tos** (`docs/operations/how-to.md`), with its first entry: how to force App Service to re-read changed Key Vault values.

## Why

App Service caches Key Vault references, so a rotated secret doesn't take effect until the worker recycles. There was no documented, copy-pasteable procedure for forcing an immediate refresh — only a one-line aside in `auth-management.md`.

## Contents

- **Environment naming table** — clarifies the asymmetric `-n` / `-g` naming so commands aren't accidentally run against the wrong environment:
  | Env | App Service (`-n`) | Resource group (`-g`) | Key Vault |
  |---|---|---|---|
  | dev | `qfa-dev-backend` | `qualitative-feedback-analysis-xomnia` | `qfa-dev-keyvault` |
  | staging | `qfa-staging-backend` | `qualitative-feedback-analysis-staging` | `qfa-staging-keyvault` |
  | prd | `qfa-prd-backend` | `qualitative-feedback-analysis-production` | `qfa-prd-keyvault` |
- **Force refresh** — the `az webapp config appsettings set … --settings KV_REFRESH_TOUCH=$(date +%s)` recipe, plus restart-only and Portal alternatives.
- **CLI token-staleness tip** for the `AuthorizationFailed` case after a recent role grant / PIM activation.
- **Versionless vs. pinned references** note.

## Wiring

- Added to the operations index table and `{toctree}`.
- Cross-linked the existing note in `auth-management.md` to the new section.

## Verification

`make docs` builds cleanly — the new `operations/how-to` page is picked up with no toctree or broken-link warnings.
