### PR TITLE
feat(postgres): guard database resources against accidental destruction

### DIFF
--- a/infra/postgres.tf
+++ b/infra/postgres.tf
@@ -21,6 +21,10 @@ resource "azurerm_subnet" "qfa_db_snet" {
 resource "azurerm_private_dns_zone" "postgres" {
   resource_group_name = data.azurerm_resource_group.main.name
   name                = "qfa-${local.env}.postgres.database.azure.com"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "postgres_vnet_link" {
@@ -46,7 +50,7 @@ resource "azurerm_postgresql_flexible_server" "db" {
     password_auth_enabled         = false
     tenant_id                     = var.tenant_id
   }
-
+  # Azure does not allow lowering storage - only increases are accepted.
   storage_mb            = var.postgres_storage_mb
   sku_name              = var.postgres_sku_name
   backup_retention_days = 30
@@ -72,4 +76,9 @@ resource "azurerm_postgresql_flexible_server_database" "app" {
   server_id = azurerm_postgresql_flexible_server.db.id
   collation = "en_US.utf8"
   charset   = "UTF8"
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes  = [name, collation, charset]
+  }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -71,7 +71,7 @@ variable "postgres_sku_name" {
 variable "postgres_storage_mb" {
   description = "Storage size in MB for PostgreSQL Flexible Server"
   type        = number
-  default     = 32768
+  default     = 32768 #Lowering this number is NOT possible and will lead to an error when running terraform apply.
 }
 
 variable "db_aad_scope" {


### PR DESCRIPTION
Closes #180 (see comments at the ticket)

## Summary

- **`azurerm_private_dns_zone`**: add `prevent_destroy = true` — deleting the zone silently breaks DB hostname resolution at runtime with no Terraform error (Azure allows the deletion even while the server references it)
- **`azurerm_postgresql_flexible_server_database`**: add `prevent_destroy = true` and `ignore_changes = [name, collation, charset]` — the database holds the actual data; these three attributes are immutable in Azure (any change forces a destroy+create), so ignoring them prevents an accidental config change from dropping and recreating the database
- **`azurerm_postgresql_flexible_server`**: add a comment on `storage_mb` clarifying that Azure rejects any downward change, making a reduction in config permanently wedge future applies
