### PR TITLE
ci: make required checks reportable for path-filtered workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,3 +92,26 @@ jobs:
         run: uv sync
       - name: Run integration + e2e tests
         run: make test-integration
+
+  # Single aggregate check to require in the branch ruleset. It depends on
+  # every other CI job and fails if any of them failed or was cancelled.
+  # Requiring this one check (instead of each job or matrix leg) keeps the
+  # ruleset stable when matrix dimensions change, and means a conditionally
+  # skipped dependency never leaves a required check stuck "waiting" —
+  # `skipped` is treated as acceptable here.
+  ci-gate:
+    if: always()
+    needs: [lint, docker-build, test, integration]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no required job failed
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "Upstream job results: ${results}"
+          for r in ${results}; do
+            if [ "${r}" = "failure" ] || [ "${r}" = "cancelled" ]; then
+              echo "::error::A required CI job did not pass (result: ${r})."
+              exit 1
+            fi
+          done
+          echo "All required CI jobs passed (or were acceptably skipped)."

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,7 +2,7 @@
 # GitHub Pages only when a release is published or when triggered
 # manually from the Actions tab.
 #
-# The build job runs everywhere and uploads the Pages artifact so that
+# The build-docs job runs everywhere and uploads the Pages artifact so that
 # doc-rot is caught early. The deploy job is gated on the event type
 # and consumes the artifact uploaded in the same workflow run
 # (actions/deploy-pages cannot reach across runs).
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build-docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +39,7 @@ jobs:
           path: docs/_build/html
 
   deploy:
-    needs: build
+    needs: build-docs
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -4,6 +4,14 @@
 #   - Automatically runs `plan` on any PR that touches infra/
 #   - Can also be triggered manually via the Actions tab
 #
+# On pull requests the workflow *always* starts, and a `changes` job detects
+# whether infra/ was touched. The real `terraform` job then runs only when it
+# was, and is otherwise skipped. This is deliberate: the `terraform` check can
+# be marked as a required status check in the branch ruleset without blocking
+# PRs that don't touch infra/ — a required check that never reports (which is
+# what a trigger-level `paths` filter produces) would leave those PRs stuck
+# "waiting", whereas a skipped check is treated as passing.
+#
 # Usage (manual):
 #   1. Select environment (dev or prd)
 #   2. Select command (plan or apply)
@@ -16,8 +24,6 @@ on:
     paths:
       - "infra/**"
   pull_request:
-    paths:
-      - "infra/**"
   workflow_dispatch:
     inputs:
       environment:
@@ -41,7 +47,31 @@ permissions:
   id-token: write
 
 jobs:
+  # Detect whether this PR touches infra/. Runs only on pull_request; on
+  # push/workflow_dispatch it is skipped and the terraform job falls back to
+  # its original always-run behaviour. On pull_request events dorny/paths-filter
+  # reads the changed-file list from the GitHub API, so no checkout is needed.
+  changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      infra: ${{ steps.filter.outputs.infra }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            infra:
+              - 'infra/**'
+
   terraform:
+    needs: changes
+    # Run for push/workflow_dispatch as before; on pull_request only when
+    # infra/ changed. always() lets this evaluate even though `changes` is
+    # skipped on non-PR events (a skipped need would otherwise skip this job).
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.infra == 'true')
     environment: ${{ inputs.environment || 'dev' }}
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
## Why

We want a branch ruleset that requires all CI checks to pass. The blocker: a required status check that references a workflow which doesn't always run (e.g. `terraform.yaml`, filtered to `infra/**`) leaves the PR stuck at *"Expected — waiting for status to be reported"*, because a **trigger-level `paths` filter produces no check run at all**. A ruleset can only see a check that actually reports.

This PR makes every check we'd want to require always report a result.

## Changes

**`ci.yaml` — aggregate gate job (require this one check)**
- Adds `ci-gate`, which `needs: [lint, docker-build, test, integration]` and runs with `if: always()`. It fails only if a dependency's result is `failure` or `cancelled`; `skipped` is treated as acceptable.
- Require **`CI / ci-gate`** in the ruleset instead of each job. This stays stable when the `lint`/`test` matrices change (no need to re-enumerate `lint (3.12, …)` etc.).

**`terraform.yaml` — job-level change detection (Approach C)**
- Removes the `pull_request: paths: [infra/**]` trigger filter so the workflow always starts on PRs.
- Adds a `changes` job using `dorny/paths-filter` (pinned to commit `7b450ff`, v4.0.2) that outputs whether `infra/**` changed.
- The `terraform` job is gated: it runs for `push`/`workflow_dispatch` as before, and on PRs only when infra changed — otherwise it reports **skipped**, which the ruleset treats as passing.
- `push` (to `main`, `infra/**`) and `workflow_dispatch` behaviour is unchanged.

## Follow-up (manual, in repo settings)

After merge, in the branch ruleset add these as required status checks:
- `CI / ci-gate`
- `Terraform / terraform`
- (plus `Docs / …` if desired — it already runs on every push)

## Validation

- `actionlint` 1.7.12 (incl. shellcheck on `run:` blocks) — clean on both files.
- YAML parses; pre-commit `yamllint` passed.

Note: `ci.yaml` still triggers on `push`, not `pull_request` — required checks resolve against the head commit, which works for same-repo branches but not fork PRs. Out of scope here; flagging for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
