### PR TITLE
docs(operations): note Build-from-commit dev path and infra-change caveat in release flow

### DIFF
--- a/docs/operations/release-flow.md
+++ b/docs/operations/release-flow.md
@@ -12,13 +12,12 @@ stateDiagram-v2
     state "GitHub draft release created<br/>Auto-deployed to dev" as Dev
     state "Release published<br/>Auto-deployed to staging (only if latest)" as Published
     state "Deployed to prd" as Prd
-    state "Ephemeral image on dev<br/>(feature branch, no release)" as Ephemeral
+    state "Ephemeral release<br/>(Build from commit — dead end)" as Ephemeral
 
     [*] --> Dev: Run Release workflow
     Dev --> Published: Click Publish on draft release
     Published --> Prd: Run Promote to prd
     [*] --> Ephemeral: Run Build from commit
-    Ephemeral --> Dev: Run Promote to dev (rejoin the release flow)
 ```
 
 Three human actions drive the whole flow: run the Release workflow, click Publish on the draft release, and run Promote to prd. Publishing is the sign-off that dev validation passed *and* the trigger for two auto-deploys — the click fires `auto-staging-on-publish.yaml` (deploys the same digest to staging) and `docs.yaml` (publishes the Sphinx docs to GitHub Pages), both with no extra workflow run. **Both auto-deploys are guarded**: they only run when the published release is the *latest* version, so finalizing an older draft has no deploy side effects (see [Publishing an older draft](#publishing-an-older-draft-to-finalize-it) and [ADR-016](../adr/016-guard-auto-deploy-on-publish.md)). The same image digest flows through all three app-runtime states — no rebuilds between environments.

--- a/docs/operations/release-flow.md
+++ b/docs/operations/release-flow.md
@@ -12,7 +12,7 @@ stateDiagram-v2
     state "GitHub draft release created<br/>Auto-deployed to dev" as Dev
     state "Release published<br/>Auto-deployed to staging (only if latest)" as Published
     state "Deployed to prd" as Prd
-    state "Ephemeral release<br/>(Build from commit)" as Ephemeral
+    state "Ephemeral release" as Ephemeral
 
     [*] --> Dev: Run Release workflow
     Dev --> Published: Click Publish on draft release

--- a/docs/operations/release-flow.md
+++ b/docs/operations/release-flow.md
@@ -20,6 +20,12 @@ stateDiagram-v2
 
 Three human actions drive the whole flow: run the Release workflow, click Publish on the draft release, and run Promote to prd. Publishing is the sign-off that dev validation passed *and* the trigger for two auto-deploys — the click fires `auto-staging-on-publish.yaml` (deploys the same digest to staging) and `docs.yaml` (publishes the Sphinx docs to GitHub Pages), both with no extra workflow run. **Both auto-deploys are guarded**: they only run when the published release is the *latest* version, so finalizing an older draft has no deploy side effects (see [Publishing an older draft](#publishing-an-older-draft-to-finalize-it) and [ADR-016](../adr/016-guard-auto-deploy-on-publish.md)). The same image digest flows through all three app-runtime states — no rebuilds between environments.
 
+> [!NOTE]
+> **Another way onto `dev`: Build from commit.** The forward flow above is not the only route into `dev`. **Build from commit** with `deploy_to_dev: true` builds an ephemeral image from any branch, tag, or SHA and deploys it straight to `dev` — no release cut, no promotion. Because it never writes a release body, that image is a dead end: it *cannot* flow onward to staging or prd. Use it to try an in-flight feature branch in `dev`; run **Promote to dev** with a released tag to return `dev` to the normal flow. See [Testing a feature branch in dev without cutting a release](#testing-a-feature-branch-in-dev-without-cutting-a-release).
+
+> [!IMPORTANT]
+> **Infrastructure changes ride a separate track — mind them.** Application releases (this section) move as a single image digest; Terraform-managed infrastructure is deployed **independently** and does *not* travel with that digest. When a release depends on new infrastructure (a Key Vault reference, an env-var binding, a new managed identity), the infra change must be applied to each environment *before* the app release that needs it — otherwise the App Service starts but fails at runtime. See [Infrastructure changes](#infrastructure-changes) below.
+
 ### Normal release (e.g. v0.4.0)
 
 1. Human runs **Release** from the Actions tab. CI runs, version bumps to v0.4.0, image builds, gets pushed to Azure Container Registry (ACR) as `qfa-backend:v0.4.0`, registry digest captured, draft release v0.4.0 created with the digest in its body, dev App Service updated to run that digest. Total: one click.

--- a/docs/operations/release-flow.md
+++ b/docs/operations/release-flow.md
@@ -12,7 +12,7 @@ stateDiagram-v2
     state "GitHub draft release created<br/>Auto-deployed to dev" as Dev
     state "Release published<br/>Auto-deployed to staging (only if latest)" as Published
     state "Deployed to prd" as Prd
-    state "Ephemeral release" as Ephemeral
+    state "Ephemeral deployment to dev" as Ephemeral
 
     [*] --> Dev: Run Release workflow
     Dev --> Published: Click Publish on draft release

--- a/docs/operations/release-flow.md
+++ b/docs/operations/release-flow.md
@@ -12,7 +12,7 @@ stateDiagram-v2
     state "GitHub draft release created<br/>Auto-deployed to dev" as Dev
     state "Release published<br/>Auto-deployed to staging (only if latest)" as Published
     state "Deployed to prd" as Prd
-    state "Ephemeral release<br/>(Build from commit — dead end)" as Ephemeral
+    state "Ephemeral release<br/>(Build from commit)" as Ephemeral
 
     [*] --> Dev: Run Release workflow
     Dev --> Published: Click Publish on draft release

--- a/docs/operations/release-flow.md
+++ b/docs/operations/release-flow.md
@@ -12,16 +12,18 @@ stateDiagram-v2
     state "GitHub draft release created<br/>Auto-deployed to dev" as Dev
     state "Release published<br/>Auto-deployed to staging (only if latest)" as Published
     state "Deployed to prd" as Prd
+    state "Ephemeral image on dev<br/>(feature branch, no release)" as Ephemeral
 
     [*] --> Dev: Run Release workflow
     Dev --> Published: Click Publish on draft release
     Published --> Prd: Run Promote to prd
+    [*] --> Ephemeral: Run Build from commit
+    Ephemeral --> Dev: Run Promote to dev (rejoin the release flow)
 ```
 
 Three human actions drive the whole flow: run the Release workflow, click Publish on the draft release, and run Promote to prd. Publishing is the sign-off that dev validation passed *and* the trigger for two auto-deploys — the click fires `auto-staging-on-publish.yaml` (deploys the same digest to staging) and `docs.yaml` (publishes the Sphinx docs to GitHub Pages), both with no extra workflow run. **Both auto-deploys are guarded**: they only run when the published release is the *latest* version, so finalizing an older draft has no deploy side effects (see [Publishing an older draft](#publishing-an-older-draft-to-finalize-it) and [ADR-016](../adr/016-guard-auto-deploy-on-publish.md)). The same image digest flows through all three app-runtime states — no rebuilds between environments.
 
-> [!NOTE]
-> **Another way onto `dev`: Build from commit.** The forward flow above is not the only route into `dev`. **Build from commit** with `deploy_to_dev: true` builds an ephemeral image from any branch, tag, or SHA and deploys it straight to `dev` — no release cut, no promotion. Because it never writes a release body, that image is a dead end: it *cannot* flow onward to staging or prd. Use it to try an in-flight feature branch in `dev`; run **Promote to dev** with a released tag to return `dev` to the normal flow. See [Testing a feature branch in dev without cutting a release](#testing-a-feature-branch-in-dev-without-cutting-a-release).
+**Another way onto `dev`: Build from commit.** The forward flow above is not the only route into `dev`. **Build from commit** with `deploy_to_dev: true` builds an ephemeral image from any branch, tag, or SHA and deploys it straight to `dev` — no release cut, no promotion. Because it never writes a release body, that image is a dead end: it *cannot* flow onward to staging or prd. Use it to try an in-flight feature branch in `dev`; run **Promote to dev** with a released tag to return `dev` to the normal flow. See [Testing a feature branch in dev without cutting a release](#testing-a-feature-branch-in-dev-without-cutting-a-release).
 
 > [!IMPORTANT]
 > **Infrastructure changes ride a separate track — mind them.** Application releases (this section) move as a single image digest; Terraform-managed infrastructure is deployed **independently** and does *not* travel with that digest. When a release depends on new infrastructure (a Key Vault reference, an env-var binding, a new managed identity), the infra change must be applied to each environment *before* the app release that needs it — otherwise the App Service starts but fails at runtime. See [Infrastructure changes](#infrastructure-changes) below.


### PR DESCRIPTION
## What

Updates `docs/operations/release-flow.md` per two requests:

1. **"Build from commit → dev" alternative in the at-a-glance section.** The top
   "App releases — promotion at a glance" section only documented the forward path
   (Release workflow → dev). Added a `> [!NOTE]` calling out that **Build from commit**
   with `deploy_to_dev: true` is another way onto `dev` — an ephemeral image from any
   ref, deployed straight to dev, that is a promotion dead end (cannot reach staging/prd).
   Links down to the existing "Testing a feature branch in dev without cutting a release"
   subsection.

2. **Infrastructure-changes shout-out.** Added a `> [!IMPORTANT]` reminding readers that
   Terraform-managed infrastructure deploys on a separate track from the app digest and
   must be applied *before* a dependent app release, with a link to the
   [Infrastructure changes](docs/operations/release-flow.md#infrastructure-changes) section below.

## Verification

- `make docs` (Sphinx `-W`, warnings-as-errors) builds clean — both new intra-page
  anchors (`#testing-a-feature-branch-in-dev-without-cutting-a-release`,
  `#infrastructure-changes`) resolve.
- Workflow input names (`ref`, `deploy_to_dev`) verified against
  `.github/workflows/build-from-commit.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
