### PR TITLE
docs(changelog): weekly delivery digest for 6-12 Jul 2026

### DIFF
--- a/changelog/2026-07-13.md
+++ b/changelog/2026-07-13.md
@@ -1,0 +1,34 @@
+# QFA — Weekly Delivery Digest
+
+**Merged 6–12 July 2026** · 11 PRs · for the Product Owner
+
+_Sorted by impact: operations (monitoring → deploy tracking) → user-facing → security → CI/CD → docs → dependencies._
+
+## What shipped
+
+| # | Category | Feature (one line) | Author | Reviewed / merged by |
+|---|---|---|---|---|
+| [#207](https://github.com/rodekruis/qualitative-feedback-analysis/pull/207) | Operations | **Azure monitoring & alerting** — Log Analytics, App Insights, 4 alert rules; validated on `dev` | olafdegraaff | mariushelf |
+| [#195](https://github.com/rodekruis/qualitative-feedback-analysis/pull/195) | Operations | **See what version is deployed where** — stamped on Azure, GitHub Environments & run summary (closes #197) | mariushelf | mariushelf |
+| [#215](https://github.com/rodekruis/qualitative-feedback-analysis/pull/215) | Feature (API) | EspoCRM metadata is now a **formal typed schema** (`created`, `coding_level_1/2/3`) — validated end-to-end (closes #143) | olafdegraaff | mariushelf |
+| [#221](https://github.com/rodekruis/qualitative-feedback-analysis/pull/221) | Feature (API) | ⏳ **TEMPORARY** — accept the retired `feedback_record_id` field so backend can deploy without waiting on the EspoCRM upgrade | mariushelf | mariushelf |
+| [#187](https://github.com/rodekruis/qualitative-feedback-analysis/pull/187) | Security | **Unified, safely-escaped prompt format** across all 5 analysis endpoints — untrusted input now escaped (closes #131) | olafdegraaff | mariushelf |
+| [#216](https://github.com/rodekruis/qualitative-feedback-analysis/pull/216) | CI/CD | Finalizing an old release **no longer regresses staging/docs** — auto-deploy guarded to latest only | mariushelf | mariushelf |
+| [#218](https://github.com/rodekruis/qualitative-feedback-analysis/pull/218) | CI/CD | CI required-checks now **report correctly** for path-filtered workflows | mariushelf | mariushelf |
+| [#213](https://github.com/rodekruis/qualitative-feedback-analysis/pull/213) | Docs | **Import/export EspoCRM flowcharts** how-to (closes #209) | olafdegraaff | olafdegraaff |
+| [#194](https://github.com/rodekruis/qualitative-feedback-analysis/pull/194) | Docs | **How to add a new endpoint** | mariushelf | mariushelf |
+| [#198](https://github.com/rodekruis/qualitative-feedback-analysis/pull/198) | Docs | **Runbook to force Key Vault reference refresh** | mariushelf | mariushelf |
+| [#219](https://github.com/rodekruis/qualitative-feedback-analysis/pull/219) | Dependencies | Bump `soupsieve` 2.8.3 → 2.8.4 | dependabot | mariushelf |
+
+**At a glance:** 2 operations · 2 feature (API) · 1 security · 2 CI/CD · 3 docs · 1 dependency bump.
+Authors: mariushelf (6), olafdegraaff (4), dependabot (1). All of Olaf's PRs reviewed by Marius; Marius's own PRs self-merged.
+
+## ⚠️ Known follow-ups from this week's work
+
+| Item | Issue |
+|---|---|
+| Teams alerts fire but don't render in the channel (the "Teams alerts for monitoring" gap) | [#222](https://github.com/rodekruis/qualitative-feedback-analysis/issues/222) |
+| App Insights telemetry reads zero — OTel data not arriving | [#223](https://github.com/rodekruis/qualitative-feedback-analysis/issues/223) |
+| Trim heavy OpenTelemetry dependencies | [#220](https://github.com/rodekruis/qualitative-feedback-analysis/issues/220) |
+| Verify metadata endpoint on `dev` with real EspoCRM payload | (unchecked box in #215) |
+| Remove the temporary `feedback_record_id` shim (#221) once all EspoCRM flowcharts are upgraded | _no issue yet_ |


### PR DESCRIPTION
Adds a PO-facing weekly delivery digest under a new `changelog/` folder.

## What
- `changelog/2026-07-13.md` — digest of the **11 PRs merged 6–12 July 2026**, sorted by impact (operations → user-facing → security → CI/CD → docs → dependencies), with a category column and author / reviewer-merger per PR.
- Includes an "at a glance" summary and a table of known follow-ups from the week's work (Teams alert delivery #222, App Insights telemetry #223, OTel deps #220, metadata dev verification, and removal of the temporary #221 shim).

## Notes
- Docs-only change; no code touched.
- #221 is flagged **temporary** in the table (compat shim to be removed once EspoCRM flowcharts are upgraded).