### PR TITLE
feat(infra): split CI/CD identity and lock down Terraform state network

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -44,7 +44,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   # Detect whether this PR touches infra/. Runs only on pull_request; on
@@ -73,7 +72,11 @@ jobs:
       always() &&
       (github.event_name != 'pull_request' || needs.changes.outputs.infra == 'true')
     environment: ${{ inputs.environment || 'dev' }}
-    runs-on: ubuntu-latest
+    # Self-hosted runner living in qfa_vnet (#176) — the only path left to the
+    # network-locked-down tfstate storage account. See infra/cicd.tf and
+    # infra/lockdown-tfstate-network.sh. Do NOT point this at ubuntu-latest
+    # again without also re-widening the storage account's network rules.
+    runs-on: [self-hosted, qfa-tfstate-runner]
     defaults:
       run:
         working-directory: infra
@@ -81,35 +84,35 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Login to Azure
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
-        with:
-          client-id: ${{ vars.AZ_CLIENT_ID }}
-          tenant-id: ${{ vars.AZ_TENANT_ID }}
-          subscription-id: ${{ vars.AZ_SUBSCRIPTION_ID }}
-
       - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
 
+      # No azure/login step: this runner authenticates as the github_terraform
+      # user-assigned identity attached to the VM (`az vm identity assign`),
+      # via IMDS — not GitHub-federated OIDC. ARM_USE_MSI + ARM_CLIENT_ID below
+      # is what tells the azurerm provider (and az CLI, if used) to use it.
       - name: Terraform init
         run: |
           terraform init \
             -backend-config="resource_group_name=${{ vars.AZ_TF_STATE_RESOURCE_GROUP }}" \
             -backend-config="storage_account_name=${{ vars.AZ_TF_STATE_STORAGE_ACCOUNT }}"
         env:
-          ARM_USE_OIDC: true
+          ARM_USE_MSI: true
+          ARM_CLIENT_ID: ${{ vars.AZ_TERRAFORM_CLIENT_ID }}
           ARM_USE_AZUREAD: true
 
       - name: Select workspace
         run: terraform workspace select ${{ inputs.environment || 'dev' }}
         env:
-          ARM_USE_OIDC: true
+          ARM_USE_MSI: true
+          ARM_CLIENT_ID: ${{ vars.AZ_TERRAFORM_CLIENT_ID }}
           ARM_USE_AZUREAD: true
 
       - name: Terraform plan
         if: ${{ inputs.command != 'apply' }}
         run: terraform plan -input=false
         env:
-          ARM_USE_OIDC: true
+          ARM_USE_MSI: true
+          ARM_CLIENT_ID: ${{ vars.AZ_TERRAFORM_CLIENT_ID }}
           ARM_USE_AZUREAD: true
           TF_VAR_subscription_id: ${{ vars.AZ_SUBSCRIPTION_ID }}
           TF_VAR_tenant_id: ${{ vars.AZ_TENANT_ID }}
@@ -124,7 +127,8 @@ jobs:
         if: inputs.command == 'apply'
         run: terraform apply -auto-approve
         env:
-          ARM_USE_OIDC: true
+          ARM_USE_MSI: true
+          ARM_CLIENT_ID: ${{ vars.AZ_TERRAFORM_CLIENT_ID }}
           ARM_USE_AZUREAD: true
           TF_VAR_subscription_id: ${{ vars.AZ_SUBSCRIPTION_ID }}
           TF_VAR_tenant_id: ${{ vars.AZ_TENANT_ID }}

--- a/docs/operations/bootstrap.md
+++ b/docs/operations/bootstrap.md
@@ -159,6 +159,10 @@ Seeding secrets is a per-environment step. See [Set up a new environment § Seed
 
 Run [Set up a new environment](setup-new-env.md) once for each environment (`dev`, `staging`, `prd`). That doc creates a Terraform workspace, applies the per-environment resources (including the managed identity + federated credential that lets GitHub Actions authenticate without any secrets), configures the per-environment GitHub variables, and seeds Key Vault secrets.
 
+## Restricting CI/CD further
+
+Two identities exist per environment (a Contributor-scoped one for `terraform.yaml`, a narrower deploy-only one for the other workflows), and the Terraform state storage account can be locked behind a private endpoint instead of staying network-open. See [Restricting CI/CD blast radius](tfstate-network-lockdown.md) — optional, but recommended once the environments above are set up.
+
 ## Subsequent infrastructure changes
 
 After the bootstrap and per-environment setup are complete, infrastructure changes follow the normal workflow:

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -9,6 +9,7 @@ Running, deploying, and observing the service.
 | [Check deployed versions](check-deployed-versions.md) | Find which app version and infra commit are live per environment (works when the app is down) |
 | [Infrastructure bootstrap](bootstrap.md) | One-time setup of the shared Terraform backend and container registry |
 | [Set up a new environment](setup-new-env.md) | Per-environment provisioning (`dev`, `staging`, `prd`) |
+| [Restricting CI/CD blast radius](tfstate-network-lockdown.md) | Split CI/CD identities + locking the Terraform state account behind a private endpoint |
 | [API key management](auth-management.md) | Adding, rotating, and revoking API keys |
 | [Settings reference](settings-reference.md) | Every environment variable the app reads |
 | [Observability](observability.md) | What gets logged, request tracing, usage queries |
@@ -24,6 +25,7 @@ release-flow
 check-deployed-versions
 bootstrap
 setup-new-env
+tfstate-network-lockdown
 auth-management
 settings-reference
 observability

--- a/docs/operations/setup-new-env.md
+++ b/docs/operations/setup-new-env.md
@@ -58,6 +58,8 @@ That path is the supported production migration flow for Entra-authenticated dat
 
 `terraform output -raw az_client_id` reads from the current workspace's state, so this step must follow the `terraform apply` above.
 
+Two identities exist per environment (see [Restricting CI/CD blast radius](tfstate-network-lockdown.md)): `az_client_id` (the deploy identity — ACR push + Website Contributor, used by `build-from-commit.yaml`/`release.yaml`/`_deploy-release.yaml`/`promote-to-*.yaml` via GitHub-federated OIDC) and `az_terraform_client_id` (the Contributor-on-RG identity used only by `terraform.yaml`, attached to the self-hosted runner VM rather than set as a GitHub Actions variable read by OIDC).
+
 ```bash
 REPO="rodekruis/qualitative-feedback-analysis"
 
@@ -65,6 +67,11 @@ gh api repos/$REPO/environments/$ENV -X PUT
 gh variable set AZ_CLIENT_ID       --env "$ENV" --repo "$REPO" --body "$(terraform output -raw az_client_id)"
 gh variable set AZ_RESOURCE_GROUP  --env "$ENV" --repo "$REPO" --body "$TF_VAR_resource_group_name"
 gh variable set AZ_APP_NAME        --env "$ENV" --repo "$REPO" --body "qfa-${ENV}-backend"
+
+# Repo-scoped (shared across environments), read by terraform.yaml. Only
+# needs to be set once and then attached to the runner VM — see
+# tfstate-network-lockdown.md.
+gh variable set AZ_TERRAFORM_CLIENT_ID --repo "$REPO" --body "$(terraform output -raw az_terraform_client_id)"
 
 # Secret (not a variable): CI's `terraform.yaml` reads this into
 # TF_VAR_teams_webhook_url. Uses `gh secret`, not `gh variable`, so the

--- a/docs/operations/tfstate-network-lockdown.md
+++ b/docs/operations/tfstate-network-lockdown.md
@@ -1,0 +1,85 @@
+# Restricting CI/CD Blast Radius and Locking Down Terraform State
+
+Addresses two related security findings ([#80](https://github.com/rodekruis/qualitative-feedback-analysis/issues/80), [#176](https://github.com/rodekruis/qualitative-feedback-analysis/issues/176)):
+
+- The single GitHub Actions identity previously held Contributor on the resource group *and* was used by every workflow, including ones that only ever touch ACR/App Service.
+- The Terraform state storage account had no network restriction — reachable from any network, gated only by Azure AD data-plane auth.
+
+## What changed
+
+Two identities instead of one (`infra/cicd.tf`):
+
+| Identity | Roles | Used by | Auth |
+|---|---|---|---|
+| `github_terraform` | Contributor on the RG, `Storage Blob Data Contributor`/`Reader` on the tfstate SA, `Reader` on the ACR | `terraform.yaml` only | VM-attached user-assigned identity (IMDS), **not** OIDC |
+| `github_deploy` | `Container Registry Repository Writer`, `Website Contributor` on the App Service only | `build-from-commit.yaml`, `release.yaml`, `_deploy-release.yaml`, `promote-to-*.yaml` | GitHub-federated OIDC (unchanged) |
+
+`terraform.yaml` now runs on a self-hosted runner living inside `qfa_vnet`, reaching the Terraform state storage account over a private endpoint. Every other workflow is unaffected — they never touch the state account, so they stay on `ubuntu-latest`.
+
+## Why not just IP-allowlist GitHub's runners
+
+`ubuntu-latest` jobs run on a large, rotating pool of Microsoft-managed IPs (published, but frequently changing). Allowlisting that range on the state account's firewall is a much weaker guarantee than it looks — closer to "allow most of Azure's public cloud" than "allow our CI" — and requires an ongoing job to keep the firewall in sync as the range rotates. A private endpoint removes the account from the public internet entirely; only the VNet (and explicitly allowlisted operator IPs, for local `terraform apply`) can reach it.
+
+## Rollout order (read before touching any of this)
+
+This is **not** a single atomic change — merging the code without doing the manual steps in order will strand CI. Follow this sequence exactly:
+
+### 1. Apply the Terraform changes (safe, additive)
+
+```bash
+cd infra
+terraform apply  # per environment/workspace, as usual
+```
+
+This creates the `github_terraform`/`github_deploy` identities, the runner subnet (`qfa-<env>-runner-snet`, `10.0.3.0/24`), and the private-endpoint subnet (`qfa-<env>-tfstate-pe-snet`, `10.0.4.0/24`). Nothing here restricts network access yet — the state account is still fully public at this point, so this step is safe to merge and apply on its own.
+
+Set the new repo-scoped variable:
+
+```bash
+gh variable set AZ_TERRAFORM_CLIENT_ID --repo "rodekruis/qualitative-feedback-analysis" \
+  --body "$(terraform output -raw az_terraform_client_id)"
+```
+
+### 2. Stand up the self-hosted runner VM
+
+Manual, one-time, per deployment:
+
+1. Create a small VM in `qfa-<env>-runner-snet` (no public IP — it only needs to reach the private endpoint created in step 4, plus GitHub's Actions API for job polling, which needs outbound internet — see note below).
+2. Attach the `github_terraform` identity: `az vm identity assign --name <vm> --resource-group <rg> --identities <az_terraform_client_id resource ID>`.
+3. Register it as a GitHub Actions runner with label `qfa-tfstate-runner` (Settings → Actions → Runners → New self-hosted runner; install as a service with `svc.sh install && svc.sh start` so it survives reboots).
+
+> **Note on egress:** the runner still needs outbound internet to poll GitHub for jobs (GitHub Actions runners are always polling/pull-based, not inbound). Only the *Terraform state account* is being locked down here — the runner is not fully air-gapped. If a fully egress-locked runner is ever wanted, that's a separate, larger change (NAT gateway + explicit allowlist of GitHub's endpoints).
+
+### 3. Verify before locking anything down
+
+Trigger `terraform.yaml` via `workflow_dispatch` (`plan`, any environment) and confirm the self-hosted runner picks it up and `terraform init`/`plan` succeed via `ARM_USE_MSI`. At this point the state account is still public, so this only proves the runner + identity path works — it does not yet prove the lockdown will succeed.
+
+### 4. Run the lockdown script
+
+Only after step 3 passes:
+
+```bash
+export TF_VAR_tf_state_resource_group_name=<rg-where-state-lives>
+export TF_VAR_tf_state_storage_account=<state-storage-account-name>
+export TF_VAR_resource_group_name=<rg-where-vnet-lives>
+export VNET_NAME=qfa-<env>-vnet
+export PE_SUBNET_NAME=qfa-<env>-tfstate-pe-snet
+export OPERATOR_IPS="<ip1> <ip2>"  # everyone who runs terraform apply/plan locally
+
+bash infra/lockdown-tfstate-network.sh
+```
+
+This creates the private endpoint + private DNS zone, then sets `--default-action Deny` on the state account with an IP allowlist for `OPERATOR_IPS`.
+
+Like `bootstrap.sh`, this script manages a resource that lives outside Terraform (the state account itself) — kept separate from `bootstrap.sh` because it is not safe to blindly re-run (re-running the IP-rule step after operator IPs have changed needs deliberate review).
+
+### 5. Re-verify after lockdown
+
+Trigger `terraform.yaml` again on the self-hosted runner — it should still succeed. If you have any lingering `ubuntu-latest` job that touches the state account, confirm it now fails (expected — that's the point).
+
+## Ongoing operational notes
+
+- **New operator**: add their IP with `az storage account network-rule add --account-name <sa> --resource-group <rg> --ip-address <ip>`.
+- **Runner VM rebuilt**: repeat step 2 above (identity attach + runner registration); no Terraform changes needed.
+- **Runner OS patching**: unlike `ubuntu-latest`, this VM does not get a fresh image per run — patch it like any other long-lived VM.
+- **If the `github_terraform` or `github_deploy` identity is ever recreated** (e.g. after `terraform destroy`): re-run [Set up a new environment § 5](setup-new-env.md#5-configure-the-environments-github-variables) for the affected environment, and re-attach the (new) `github_terraform` identity to the runner VM.

--- a/infra/cicd.tf
+++ b/infra/cicd.tf
@@ -1,89 +1,111 @@
 # =============================================================================
 # GitHub CI/CD
 # =============================================================================
-# Allow GitHub actions to read/write to the container registry, and modify the resource group
-# (e.g., to manage app service settings etc).
+# Two identities, split by blast radius (#80) and network reachability (#176):
 #
-# How it works:
-# 1. we create a managed identity
-# 2. assign roles "Container Registry Repository Writer" and "Contributor" to the managed identity
-# 3. add a federated identity credential to the managed identity
+# github_terraform: Contributor on the RG + tfstate data-plane access.
+#   Used only by terraform.yaml, which needs to create/update/delete arbitrary
+#   RG resources. Attached as a user-assigned identity to the self-hosted
+#   runner VM that lives inside qfa_vnet (see runner_snet below) and
+#   authenticates via that VM's IMDS (ARM_USE_MSI), not GitHub OIDC — the
+#   runner has no route to the public internet once the tfstate storage
+#   account network lockdown (infra/lockdown-tfstate-network.sh) is applied.
 #
-# Github actions authenticate as the managed identity via the federated identity credential.
-# This happens automatically -- Azure "knows" that an action is triggered from the
-# repository and environment specified in the federated identity credential.
+# github_deploy: narrow, deployment-only permissions (ACR push, Website
+#   Contributor on the App Service only). Used by build-from-commit.yaml,
+#   release.yaml, _deploy-release.yaml, and the promote-to-* workflows, all of
+#   which keep running on ubuntu-latest via GitHub-federated OIDC exactly as
+#   before — none of them touch tfstate.
+#
+# When to revisit:
+#   If a third workflow needs RG-level access, resist folding it into either
+#   identity above — give it its own scoped role instead, or the blast-radius
+#   narrowing this split exists for erodes again.
 
-resource "azurerm_user_assigned_identity" "github" {
-  name                = local.managed_identity_name
+resource "azurerm_user_assigned_identity" "github_terraform" {
+  name                = local.managed_identity_terraform_name
   resource_group_name = data.azurerm_resource_group.main.name
   location            = data.azurerm_resource_group.main.location
 }
 
-# Grant GitHub Actions write access to ACR (for CI/CD image builds)
-resource "azurerm_role_assignment" "github_acr_repository_writer" {
-  scope                = local.acr_id
-  role_definition_name = "Container Registry Repository Writer"
-  principal_id         = azurerm_user_assigned_identity.github.principal_id
+resource "azurerm_user_assigned_identity" "github_deploy" {
+  name                = local.managed_identity_deploy_name
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = data.azurerm_resource_group.main.location
 }
 
-# GitHub Actions identity gets Contributor on the resource group.
-#
-# Why Contributor and not a narrower role:
-#   terraform.yaml runs `terraform apply` which creates, updates, and deletes
-#   arbitrary resources in this RG (App Service, Key Vault, VNet, subnets,
-#   managed identities). That requires Contributor-level breadth. A scoped
-#   role like Website Contributor would only cover the App Service, breaking
-#   all other Terraform-managed resources.
-#
-# When to revisit:
-#   If the team grows and you want least-privilege separation, split into two
-#   identities: one for Terraform (Contributor on the RG, used only by
-#   terraform.yaml) and one for deployment (Website Contributor on the App
-#   Service, used by the release/promote workflows). That requires a second
-#   managed identity, a second federated credential, and a second set of
-#   GitHub environment variables.
-resource "azurerm_role_assignment" "github_contributor" {
+# --- github_terraform: terraform.yaml only ---------------------------------
+
+# terraform.yaml runs `terraform apply`, which creates, updates, and deletes
+# arbitrary resources in this RG (App Service, Key Vault, VNet, subnets,
+# managed identities). That requires Contributor-level breadth. A scoped role
+# like Website Contributor would only cover the App Service, breaking all
+# other Terraform-managed resources.
+resource "azurerm_role_assignment" "github_terraform_contributor" {
   scope                = data.azurerm_resource_group.main.id
   role_definition_name = "Contributor"
-  principal_id         = azurerm_user_assigned_identity.github.principal_id
+  principal_id         = azurerm_user_assigned_identity.github_terraform.principal_id
 }
 
-# GitHub Actions identity needs data-plane access to the Terraform state
-# storage account so `terraform init`/`plan`/`apply` in CI can read and write
-# the state blob. Scoped to the SA (not the state RG) so the assignment cannot
-# accidentally widen if other resources are later added to that RG.
-resource "azurerm_role_assignment" "github_tfstate_blob_contributor" {
+# Data-plane access to the Terraform state storage account so
+# `terraform init`/`plan`/`apply` in CI can read and write the state blob.
+# Scoped to the SA (not the state RG) so the assignment cannot accidentally
+# widen if other resources are later added to that RG.
+resource "azurerm_role_assignment" "github_terraform_tfstate_blob_contributor" {
   scope                = local.tfstate_sa_id
   role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = azurerm_user_assigned_identity.github.principal_id
+  principal_id         = azurerm_user_assigned_identity.github_terraform.principal_id
 }
 
 # CI identity needs to read role assignments at shared-infra scopes so that
 # `terraform plan` can refresh the azurerm_role_assignment resources defined
-# here and in app_service.tf. The narrower data-plane roles already granted
-# (Container Registry Repository Writer, Storage Blob Data Contributor) do
-# not include Microsoft.Authorization/roleAssignments/read — only control-
-# plane roles do. `Reader` scoped per-resource is the least-privilege fit:
-# it grants `*/read` on exactly these two resources, nothing else.
+# here and in app_service.tf. The narrower data-plane role already granted
+# (Storage Blob Data Contributor) does not include
+# Microsoft.Authorization/roleAssignments/read — only control-plane roles do.
+# `Reader` scoped per-resource is the least-privilege fit: it grants `*/read`
+# on exactly these two resources, nothing else.
 #
 # Write-side (apply creating or modifying role assignments at these scopes)
 # still requires operator credentials in a local apply. Reader covers the
 # steady-state CI plan/apply cycle.
-resource "azurerm_role_assignment" "github_acr_reader" {
+resource "azurerm_role_assignment" "github_terraform_acr_reader" {
   scope                = local.acr_id
   role_definition_name = "Reader"
-  principal_id         = azurerm_user_assigned_identity.github.principal_id
+  principal_id         = azurerm_user_assigned_identity.github_terraform.principal_id
 }
 
-resource "azurerm_role_assignment" "github_tfstate_reader" {
+resource "azurerm_role_assignment" "github_terraform_tfstate_reader" {
   scope                = local.tfstate_sa_id
   role_definition_name = "Reader"
-  principal_id         = azurerm_user_assigned_identity.github.principal_id
+  principal_id         = azurerm_user_assigned_identity.github_terraform.principal_id
 }
 
-resource "azurerm_federated_identity_credential" "github_environment" {
-  name                      = "gh-qualitative-feedback-analysis-${local.env}"
-  user_assigned_identity_id = azurerm_user_assigned_identity.github.id
+# No federated_identity_credential for github_terraform: it authenticates via
+# the self-hosted runner VM's IMDS (user-assigned identity attached to the
+# VM), not OIDC. See infra/README (runner setup) for the manual `az vm
+# identity assign` step — Terraform does not manage the runner VM itself,
+# the same way bootstrap.sh's resources live outside Terraform.
+
+# --- github_deploy: build-from-commit / release / _deploy-release / promote-to-* ---
+
+# Grant GitHub Actions write access to ACR (for CI/CD image builds)
+resource "azurerm_role_assignment" "github_deploy_acr_repository_writer" {
+  scope                = local.acr_id
+  role_definition_name = "Container Registry Repository Writer"
+  principal_id         = azurerm_user_assigned_identity.github_deploy.principal_id
+}
+
+# Scoped to the App Service only — these workflows update container image
+# and tags, nothing else in the RG.
+resource "azurerm_role_assignment" "github_deploy_website_contributor" {
+  scope                = azurerm_linux_web_app.backend.id
+  role_definition_name = "Website Contributor"
+  principal_id         = azurerm_user_assigned_identity.github_deploy.principal_id
+}
+
+resource "azurerm_federated_identity_credential" "github_deploy_environment" {
+  name                      = "gh-qualitative-feedback-analysis-deploy-${local.env}"
+  user_assigned_identity_id = azurerm_user_assigned_identity.github_deploy.id
   audience                  = ["api://AzureADTokenExchange"]
   issuer                    = "https://token.actions.githubusercontent.com"
   subject                   = "repo:${var.github_repo}:environment:${local.github_environment}"

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -1,12 +1,13 @@
 locals {
-  env                   = terraform.workspace
-  app_name              = "qfa-${local.env}-backend"
-  plan_name             = "qfa-${local.env}-plan" # Azure Web Service plan name
-  vnet_name             = "qfa-${local.env}-vnet"
-  keyvault_name         = "qfa-${local.env}-keyvault"
-  managed_identity_name = "qfa-${local.env}-github"
-  github_environment    = local.env
-  db_aad_principal_name = local.app_name # system-assigned MI name matches the App Service name
+  env                             = terraform.workspace
+  app_name                        = "qfa-${local.env}-backend"
+  plan_name                       = "qfa-${local.env}-plan" # Azure Web Service plan name
+  vnet_name                       = "qfa-${local.env}-vnet"
+  keyvault_name                   = "qfa-${local.env}-keyvault"
+  managed_identity_terraform_name = "qfa-${local.env}-github-terraform"
+  managed_identity_deploy_name    = "qfa-${local.env}-github-deploy"
+  github_environment              = local.env
+  db_aad_principal_name           = local.app_name # system-assigned MI name matches the App Service name
 
   # Resource IDs for shared infra. Constructed deterministically from variables
   # rather than looked up via `data` sources so the CI identity does not need

--- a/infra/lockdown-tfstate-network.sh
+++ b/infra/lockdown-tfstate-network.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Locks the Terraform state storage account down to a private endpoint only
+# (#176). Run this ONCE, manually, and only after:
+#   1. `terraform apply` has run at least once with the github_terraform /
+#      github_deploy identity split (infra/cicd.tf) and the runner/PE subnets
+#      (infra/virtual_network.tf) already live.
+#   2. The self-hosted runner VM exists, has the github_terraform
+#      user-assigned identity attached, and has successfully run a
+#      terraform.yaml plan against the still-public storage account.
+#
+# Until step 2 is verified, do NOT run this script — it cuts off every path
+# to the state account except the private endpoint created here, and
+# ubuntu-latest-hosted CI has no route to it.
+#
+# Like bootstrap.sh, this manages a resource (the state SA) that lives
+# outside Terraform's management — kept as a separate script rather than
+# folded into bootstrap.sh because bootstrap.sh is safe to re-run and this
+# is not: re-running the network-rule step after operator IPs have changed
+# requires deliberate review, not a blind rerun.
+set -euo pipefail
+
+TF_STATE_RG="${TF_VAR_tf_state_resource_group_name:?must be set: export TF_VAR_tf_state_resource_group_name=<rg-where-state-lives>}"
+SA="${TF_VAR_tf_state_storage_account:?must be set: export TF_VAR_tf_state_storage_account=<state-storage-account-name>}"
+RG="${TF_VAR_resource_group_name:?must be set: export TF_VAR_resource_group_name=<rg-where-vnet-lives>}"
+VNET_NAME="${VNET_NAME:?must be set: export VNET_NAME=<qfa-<env>-vnet, e.g. qfa-dev-vnet>}"
+PE_SUBNET_NAME="${PE_SUBNET_NAME:?must be set: export PE_SUBNET_NAME=<qfa-<env>-tfstate-pe-snet>}"
+OPERATOR_IPS="${OPERATOR_IPS:-}" # space-separated list, e.g. "1.2.3.4 5.6.7.8"
+
+echo "Creating private endpoint for $SA in $VNET_NAME/$PE_SUBNET_NAME..."
+az network private-endpoint create \
+  --name "pe-${SA}-blob" \
+  --resource-group "$RG" \
+  --vnet-name "$VNET_NAME" \
+  --subnet "$PE_SUBNET_NAME" \
+  --private-connection-resource-id "$(az storage account show --name "$SA" --resource-group "$TF_STATE_RG" --query id -o tsv)" \
+  --group-id blob \
+  --connection-name "pe-${SA}-blob-connection"
+
+echo "Creating private DNS zone and linking it to $VNET_NAME..."
+az network private-dns zone create \
+  --resource-group "$RG" \
+  --name "privatelink.blob.core.windows.net"
+
+az network private-dns link vnet create \
+  --resource-group "$RG" \
+  --zone-name "privatelink.blob.core.windows.net" \
+  --name "${VNET_NAME}-tfstate-link" \
+  --virtual-network "$VNET_NAME" \
+  --registration-enabled false
+
+az network private-endpoint dns-zone-group create \
+  --resource-group "$RG" \
+  --endpoint-name "pe-${SA}-blob" \
+  --name default \
+  --private-dns-zone "privatelink.blob.core.windows.net" \
+  --zone-name blob
+
+echo "Denying public network access on $SA, with an allowlist for operator IPs..."
+az storage account update \
+  --name "$SA" \
+  --resource-group "$TF_STATE_RG" \
+  --default-action Deny \
+  --public-network-access Enabled # keep Enabled + Deny-by-default so the IP rules below still apply; only the private endpoint bypasses network rules entirely
+
+if [ -n "$OPERATOR_IPS" ]; then
+  for ip in $OPERATOR_IPS; do
+    echo "Allowing operator IP $ip..."
+    az storage account network-rule add \
+      --account-name "$SA" \
+      --resource-group "$TF_STATE_RG" \
+      --ip-address "$ip"
+  done
+else
+  echo "::warning:: No OPERATOR_IPS set — local 'terraform apply'/'plan' will fail until an operator IP is allowlisted."
+fi
+
+echo "Done. Verify: a terraform.yaml run on the self-hosted runner still succeeds,"
+echo "and that a run on ubuntu-latest (if you still have one to compare against) now fails."

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -14,8 +14,13 @@ output "keyvault_uri" {
 }
 
 output "az_client_id" {
-  description = "AZ_CLIENT_ID — client ID of the managed identity used by GitHub Actions (OIDC)"
-  value       = azurerm_user_assigned_identity.github.client_id
+  description = "AZ_CLIENT_ID — client ID of the github_deploy managed identity used by build-from-commit.yaml, release.yaml, _deploy-release.yaml, and promote-to-*.yaml (GitHub-federated OIDC)"
+  value       = azurerm_user_assigned_identity.github_deploy.client_id
+}
+
+output "az_terraform_client_id" {
+  description = "AZ_TERRAFORM_CLIENT_ID — client ID of the github_terraform managed identity. Attach it as a user-assigned identity to the self-hosted runner VM (`az vm identity assign --identities <id>`); terraform.yaml authenticates via the VM's IMDS (ARM_USE_MSI + ARM_CLIENT_ID), not OIDC"
+  value       = azurerm_user_assigned_identity.github_terraform.client_id
 }
 
 output "postgres_server_fqdn" {

--- a/infra/virtual_network.tf
+++ b/infra/virtual_network.tf
@@ -10,3 +10,26 @@ resource "azurerm_virtual_network" "qfa_vnet" {
   resource_group_name = data.azurerm_resource_group.main.name
   address_space       = ["10.0.0.0/16"]
 }
+
+# Self-hosted GitHub Actions runner for terraform.yaml (#176). The VM itself
+# is not Terraform-managed (chicken-and-egg: it's what reaches the tfstate
+# backend), same pattern as bootstrap.sh's resources — see
+# infra/lockdown-tfstate-network.sh and the PR runbook for the manual setup.
+resource "azurerm_subnet" "qfa_runner_snet" {
+  resource_group_name  = data.azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.qfa_vnet.name
+  name                 = "qfa-${local.env}-runner-snet"
+  address_prefixes     = ["10.0.3.0/24"]
+}
+
+# Private endpoint for the tfstate storage account's blob service. Also
+# created outside Terraform (the SA itself is), by
+# infra/lockdown-tfstate-network.sh. `private_endpoint_network_policies`
+# disabled is required for a subnet that hosts private endpoints.
+resource "azurerm_subnet" "qfa_tfstate_pe_snet" {
+  resource_group_name               = data.azurerm_resource_group.main.name
+  virtual_network_name              = azurerm_virtual_network.qfa_vnet.name
+  name                              = "qfa-${local.env}-tfstate-pe-snet"
+  address_prefixes                  = ["10.0.4.0/24"]
+  private_endpoint_network_policies = "Disabled"
+}


### PR DESCRIPTION
Addresses #80 and #176 together — they resolve into one coherent change rather than two separate ones (see discussion on #176).

## What this does

- **#80** — splits the single GitHub Actions managed identity into two, scoped to what each workflow actually needs:
  - `github_terraform`: Contributor on the RG + Terraform state data-plane access. Used **only** by `terraform.yaml`.
  - `github_deploy`: ACR push + `Website Contributor` on the App Service only. Used by `build-from-commit.yaml`, `release.yaml`, `_deploy-release.yaml`, `promote-to-*.yaml` — unchanged otherwise, still `ubuntu-latest` + GitHub-federated OIDC.
- **#176** — `terraform.yaml` moves to a self-hosted runner living inside `qfa_vnet`, authenticating via the runner VM's attached `github_terraform` identity (IMDS) instead of OIDC. This lets the Terraform state storage account be locked behind a private endpoint (`infra/lockdown-tfstate-network.sh`) instead of staying reachable from the public internet.
- IP allowlisting (the option originally raised on #176) is kept, but only for human operators running `terraform apply`/`plan` locally — for CI, a private endpoint is a strictly stronger guarantee than allowlisting GitHub's large, rotating hosted-runner IP range.

Full rationale and the "why not just IP-allowlist CI" reasoning: [docs/operations/tfstate-network-lockdown.md](docs/operations/tfstate-network-lockdown.md).

## Why this is a draft, not ready to merge yet

This is a **staged rollout, not a single atomic change**. Merging the code alone does not flip the network lockdown — but `terraform.yaml`'s `runs-on` does change in this PR to target the not-yet-existent self-hosted runner, so **do not merge until the manual steps below are done and verified**, or `terraform.yaml` will have no runner to execute on.

### Before merging

1. `terraform apply` this branch's Terraform changes (safe/additive — new identities + new subnets, does not restrict any existing access).
2. Set the new repo variable: `gh variable set AZ_TERRAFORM_CLIENT_ID --body "$(terraform output -raw az_terraform_client_id)"`.
3. Stand up the self-hosted runner VM in the new `qfa-<env>-runner-snet` subnet, attach the `github_terraform` identity (`az vm identity assign`), register it as a GitHub Actions runner with label `qfa-tfstate-runner`.
4. Trigger `terraform.yaml` via `workflow_dispatch` (`plan`) and confirm it runs successfully on the new runner via `ARM_USE_MSI`. At this point the state account is still public — this only proves the runner+identity path works.

### After merging

5. Run `infra/lockdown-tfstate-network.sh` (manual, one-time — see the script header and the doc page for required env vars, including an `OPERATOR_IPS` allowlist for anyone running Terraform locally).
6. Re-verify `terraform.yaml` still succeeds on the self-hosted runner after lockdown.

Step-by-step detail, including exact commands, is in [docs/operations/tfstate-network-lockdown.md](docs/operations/tfstate-network-lockdown.md) — please follow that rather than this summary when actually doing the rollout.

## What does *not* change

- `build-from-commit.yaml`, `release.yaml`, `_deploy-release.yaml`, `promote-to-*.yaml` — these never touch the Terraform state account, so they stay on `ubuntu-latest` with the existing GitHub-federated OIDC flow, unaffected by the lockdown.

closes #80
closes #176