### PR TITLE
fix(coding): surface near-miss explanation when threshold rejects eve…

### DIFF
--- a/docs/rest-api/index.md
+++ b/docs/rest-api/index.md
@@ -60,6 +60,8 @@ Per-record inference endpoints (`/v1/summarize`, `/v1/assign-codes`, `/v1/detect
 
 Empty `content` is accepted on every endpoint and never causes a 422. A record with empty content carries no information, so it is dropped (bulk) or short-circuited to a 200 empty result with no LLM call (per-record) — see each endpoint's reference for the exact empty-result shape. This keeps a single blank EspoCRM description from silently failing a whole request (issue #138).
 
+`POST /v1/assign-codes` accepts an optional `confidence_threshold`; codes whose judge score falls below it are filtered out. If every candidate at every hierarchy level is filtered out this way, the response is a 200 with a single `assigned_codes` entry whose `coding_level_*`/`confidence_*` fields are `null` and whose `explanation` describes the highest-scoring rejected candidate — instead of an unexplained empty list.
+
 ## Usage endpoint response shape
 
 All usage endpoints return aggregated stats in two parallel views:

--- a/docs/rest-api/index.md
+++ b/docs/rest-api/index.md
@@ -60,7 +60,7 @@ Per-record inference endpoints (`/v1/summarize`, `/v1/assign-codes`, `/v1/detect
 
 Empty `content` is accepted on every endpoint and never causes a 422. A record with empty content carries no information, so it is dropped (bulk) or short-circuited to a 200 empty result with no LLM call (per-record) — see each endpoint's reference for the exact empty-result shape. This keeps a single blank EspoCRM description from silently failing a whole request (issue #138).
 
-`POST /v1/assign-codes` accepts an optional `confidence_threshold`; codes whose judge score falls below it are filtered out. If every candidate at every hierarchy level is filtered out this way, the response is a 200 with a single `assigned_codes` entry whose `coding_level_*`/`confidence_*` fields are `null` and whose `explanation` describes the highest-scoring rejected candidate — instead of an unexplained empty list.
+`POST /v1/assign-codes` accepts an optional `confidence_threshold`; codes whose judge score falls below it are filtered out. If every candidate at every hierarchy level is filtered out this way, the response is a 200 with a single `assigned_codes` entry whose `coding_level_*`/`confidence_*` fields are `null` and whose `explanation` combines every rejected candidate's explanation (highest-scoring first) — instead of an unexplained empty list.
 
 ## Usage endpoint response shape
 

--- a/src/qfa/api/routes.py
+++ b/src/qfa/api/routes.py
@@ -405,6 +405,11 @@ async def assign_codes(
 
     If the record's ``content`` is empty the response is a 200 with an empty
     ``assigned_codes`` list, returned without an LLM call (issue #138).
+
+    If every candidate is filtered out by ``confidence_threshold``, the
+    response is a 200 with a single ``assigned_codes`` entry whose
+    ``coding_level_*``/``confidence_*`` fields are null and whose
+    ``explanation`` describes the highest-scoring rejected candidate.
     """
     deadline = datetime.now(UTC) + timedelta(seconds=120)
 

--- a/src/qfa/api/routes.py
+++ b/src/qfa/api/routes.py
@@ -409,7 +409,8 @@ async def assign_codes(
     If every candidate is filtered out by ``confidence_threshold``, the
     response is a 200 with a single ``assigned_codes`` entry whose
     ``coding_level_*``/``confidence_*`` fields are null and whose
-    ``explanation`` describes the highest-scoring rejected candidate.
+    ``explanation`` combines every rejected candidate's explanation,
+    highest-scoring first.
     """
     deadline = datetime.now(UTC) + timedelta(seconds=120)
 

--- a/src/qfa/api/schemas.py
+++ b/src/qfa/api/schemas.py
@@ -825,8 +825,8 @@ class ApiAssignedCode(BaseModel):
         description=(
             "Judge explanation combining reasoning from all hierarchy "
             "levels. When no code cleared the confidence threshold, this "
-            "holds the explanation for the highest-scoring rejected "
-            "candidate instead."
+            "combines every rejected candidate's explanation instead, "
+            "highest-scoring first."
         )
     )
 

--- a/src/qfa/api/schemas.py
+++ b/src/qfa/api/schemas.py
@@ -769,8 +769,20 @@ class ApiAssignCodesRequest(ApiSingleInferenceRequestBase):
 class ApiAssignedCode(BaseModel):
     """A single code assigned to a feedback record with its hierarchical path."""
 
-    coding_level_1_id: str = Field(description="ID of the selected level 1 code.")
-    coding_level_1_name: str = Field(description="Name of the selected level 1 code.")
+    coding_level_1_id: str | None = Field(
+        default=None,
+        description=(
+            "ID of the selected level 1 code; null when no code cleared the "
+            "confidence threshold (see explanation)."
+        ),
+    )
+    coding_level_1_name: str | None = Field(
+        default=None,
+        description=(
+            "Name of the selected level 1 code; null when no code cleared "
+            "the confidence threshold (see explanation)."
+        ),
+    )
     coding_level_2_id: str | None = Field(
         default=None,
         description="ID of the selected level 2 code; null when depth < 2.",
@@ -787,7 +799,13 @@ class ApiAssignedCode(BaseModel):
         default=None,
         description="Name of the selected level 3 code; null when depth < 3.",
     )
-    confidence_level_1: float = Field(description="Judge confidence at level 1 (0-1).")
+    confidence_level_1: float | None = Field(
+        default=None,
+        description=(
+            "Judge confidence at level 1 (0-1); null when no code cleared "
+            "the confidence threshold."
+        ),
+    )
     confidence_level_2: float | None = Field(
         default=None,
         description="Judge confidence at level 2 (0-1); null when depth < 2.",
@@ -796,11 +814,20 @@ class ApiAssignedCode(BaseModel):
         default=None,
         description="Judge confidence at level 3 (0-1); null when depth < 3.",
     )
-    confidence_aggregate: float = Field(
-        description="Minimum of the per-level confidences."
+    confidence_aggregate: float | None = Field(
+        default=None,
+        description=(
+            "Minimum of the per-level confidences; null when no code "
+            "cleared the confidence threshold."
+        ),
     )
     explanation: str = Field(
-        description="Judge explanation combining reasoning from all hierarchy levels."
+        description=(
+            "Judge explanation combining reasoning from all hierarchy "
+            "levels. When no code cleared the confidence threshold, this "
+            "holds the explanation for the highest-scoring rejected "
+            "candidate instead."
+        )
     )
 
 

--- a/src/qfa/domain/models.py
+++ b/src/qfa/domain/models.py
@@ -280,8 +280,20 @@ class AssignedCodeModel(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    coding_level_1_id: str = Field(description="ID of the selected level 1 code.")
-    coding_level_1_name: str = Field(description="Name of the selected level 1 code.")
+    coding_level_1_id: str | None = Field(
+        default=None,
+        description=(
+            "ID of the selected level 1 code; null when no code cleared the "
+            "confidence threshold (see explanation)."
+        ),
+    )
+    coding_level_1_name: str | None = Field(
+        default=None,
+        description=(
+            "Name of the selected level 1 code; null when no code cleared the "
+            "confidence threshold (see explanation)."
+        ),
+    )
     coding_level_2_id: str | None = Field(
         default=None,
         description="ID of the selected level 2 code; null when depth < 2.",
@@ -298,8 +310,12 @@ class AssignedCodeModel(BaseModel):
         default=None,
         description="Name of the selected level 3 code; null when depth < 3.",
     )
-    confidence_level_1: float = Field(
-        description="Judge confidence that the level 1 code fits the feedback record (0-1)."
+    confidence_level_1: float | None = Field(
+        default=None,
+        description=(
+            "Judge confidence that the level 1 code fits the feedback record "
+            "(0-1); null when no code cleared the confidence threshold."
+        ),
     )
     confidence_level_2: float | None = Field(
         default=None,
@@ -309,11 +325,19 @@ class AssignedCodeModel(BaseModel):
         default=None,
         description="Judge confidence that the level 3 code fits the feedback record (0-1); null when depth < 3.",
     )
-    confidence_aggregate: float = Field(
-        description="Overall confidence, computed as min of per-level confidences."
+    confidence_aggregate: float | None = Field(
+        default=None,
+        description=(
+            "Overall confidence, computed as min of per-level confidences; "
+            "null when no code cleared the confidence threshold."
+        ),
     )
     explanation: str = Field(
-        description="Judge explanation combining scores from all hierarchy levels."
+        description=(
+            "Judge explanation combining scores from all hierarchy levels. "
+            "When no code cleared the confidence threshold, this holds the "
+            "explanation for the highest-scoring rejected candidate instead."
+        )
     )
 
 

--- a/src/qfa/domain/models.py
+++ b/src/qfa/domain/models.py
@@ -335,8 +335,9 @@ class AssignedCodeModel(BaseModel):
     explanation: str = Field(
         description=(
             "Judge explanation combining scores from all hierarchy levels. "
-            "When no code cleared the confidence threshold, this holds the "
-            "explanation for the highest-scoring rejected candidate instead."
+            "When no code cleared the confidence threshold, this combines "
+            "every rejected candidate's explanation instead, highest-scoring "
+            "first."
         )
     )
 

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -219,6 +219,18 @@ class _ScoredCode:
         )
 
 
+def _combine_rejected_explanations(rejected: list[_ScoredCode]) -> str:
+    """Join every threshold-rejected candidate's explanation into one string.
+
+    Highest-scoring rejection first, each labelled with its hierarchy path
+    so a reader can tell which candidate an explanation belongs to.
+    """
+    ordered = sorted(rejected, key=lambda c: c.confidence_aggregate, reverse=True)
+    return " | ".join(
+        f"{' > '.join(name for _, name in c.path)}: {c.explanation}" for c in ordered
+    )
+
+
 @dataclass
 class _SlotTiming:
     """Split timing for one semaphore-bounded hierarchical LLM call.
@@ -1236,7 +1248,8 @@ class Orchestrator:
             ``confidence_threshold`` filters out every candidate, the record's
             ``assigned_codes`` holds a single entry with null
             ``coding_level_*``/``confidence_*`` fields and an ``explanation``
-            describing the highest-scoring rejected candidate.
+            combining every rejected candidate's reasoning, highest-scoring
+            first.
 
         Raises
         ------
@@ -1253,7 +1266,7 @@ class Orchestrator:
         self._check_coding_deadline(deadline)
 
         candidates: list[_ScoredCode] = []
-        best_rejected: list[_ScoredCode | None] = [None]
+        rejected: list[_ScoredCode] = []
         await self._traverse_coding_level(
             feedback_record=feedback_record,
             level_nodes=list(request.coding_levels.root_codes),
@@ -1266,7 +1279,7 @@ class Orchestrator:
             tenant_id=request.tenant_id,
             deadline=deadline,
             candidates=candidates,
-            best_rejected=best_rejected,
+            rejected=rejected,
         )
 
         candidates.sort(key=lambda c: c.confidence_aggregate, reverse=True)
@@ -1290,12 +1303,12 @@ class Orchestrator:
                 )
                 for c in top
             ]
-        elif not candidates and best_rejected[0] is not None:
+        elif rejected:
             # Every candidate was filtered out by confidence_threshold: surface
-            # the highest-scoring rejected candidate's explanation instead of
-            # an unexplained empty list.
+            # every rejected candidate's explanation instead of an
+            # unexplained empty list.
             assigned_codes = [
-                AssignedCodeModel(explanation=best_rejected[0].explanation)
+                AssignedCodeModel(explanation=_combine_rejected_explanations(rejected))
             ]
         else:
             assigned_codes = []
@@ -1402,7 +1415,7 @@ class Orchestrator:
         tenant_id: str,
         deadline: datetime,
         candidates: list[_ScoredCode],
-        best_rejected: list[_ScoredCode | None],
+        rejected: list[_ScoredCode],
     ) -> None:
         """Recursively pick and judge codes at one level, descending into children."""
         level_label = f"Code level {level_num}"
@@ -1428,15 +1441,11 @@ class Orchestrator:
             new_scores = [*accumulated_scores, judge.score]
             new_explanations = [*accumulated_explanations, judge.explanation]
             if threshold is not None and judge.score < threshold:
-                rejected = _ScoredCode(
-                    path=new_path, scores=new_scores, explanations=new_explanations
+                rejected.append(
+                    _ScoredCode(
+                        path=new_path, scores=new_scores, explanations=new_explanations
+                    )
                 )
-                if (
-                    best_rejected[0] is None
-                    or rejected.confidence_aggregate
-                    > best_rejected[0].confidence_aggregate
-                ):
-                    best_rejected[0] = rejected
                 continue
             if node.children:
                 await self._traverse_coding_level(
@@ -1451,7 +1460,7 @@ class Orchestrator:
                     tenant_id=tenant_id,
                     deadline=deadline,
                     candidates=candidates,
-                    best_rejected=best_rejected,
+                    rejected=rejected,
                 )
             else:
                 candidates.append(

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -1232,7 +1232,11 @@ class Orchestrator:
         Returns
         -------
         CodingAssignmentResult
-            Per-record leaf codes from ``classify_feedback``.
+            Per-record leaf codes from ``classify_feedback``. If
+            ``confidence_threshold`` filters out every candidate, the record's
+            ``assigned_codes`` holds a single entry with null
+            ``coding_level_*``/``confidence_*`` fields and an ``explanation``
+            describing the highest-scoring rejected candidate.
 
         Raises
         ------
@@ -1249,6 +1253,7 @@ class Orchestrator:
         self._check_coding_deadline(deadline)
 
         candidates: list[_ScoredCode] = []
+        best_rejected: list[_ScoredCode | None] = [None]
         await self._traverse_coding_level(
             feedback_record=feedback_record,
             level_nodes=list(request.coding_levels.root_codes),
@@ -1261,33 +1266,46 @@ class Orchestrator:
             tenant_id=request.tenant_id,
             deadline=deadline,
             candidates=candidates,
+            best_rejected=best_rejected,
         )
 
         candidates.sort(key=lambda c: c.confidence_aggregate, reverse=True)
         top = candidates[: request.max_codes]
 
-        coded: list[CodedFeedbackRecordModel] = []
-        coded.append(
+        assigned_codes: list[AssignedCodeModel]
+        if top:
+            assigned_codes = [
+                AssignedCodeModel(
+                    coding_level_1_id=c.path[0][0],
+                    coding_level_1_name=c.path[0][1],
+                    coding_level_2_id=c.path[1][0] if len(c.path) > 1 else None,
+                    coding_level_2_name=c.path[1][1] if len(c.path) > 1 else None,
+                    coding_level_3_id=c.path[2][0] if len(c.path) > 2 else None,
+                    coding_level_3_name=c.path[2][1] if len(c.path) > 2 else None,
+                    confidence_level_1=c.scores[0],
+                    confidence_level_2=c.scores[1] if len(c.scores) > 1 else None,
+                    confidence_level_3=c.scores[2] if len(c.scores) > 2 else None,
+                    confidence_aggregate=c.confidence_aggregate,
+                    explanation=c.explanation,
+                )
+                for c in top
+            ]
+        elif not candidates and best_rejected[0] is not None:
+            # Every candidate was filtered out by confidence_threshold: surface
+            # the highest-scoring rejected candidate's explanation instead of
+            # an unexplained empty list.
+            assigned_codes = [
+                AssignedCodeModel(explanation=best_rejected[0].explanation)
+            ]
+        else:
+            assigned_codes = []
+
+        coded = [
             CodedFeedbackRecordModel(
                 feedback_record_id=feedback_record.id,
-                assigned_codes=tuple(
-                    AssignedCodeModel(
-                        coding_level_1_id=c.path[0][0],
-                        coding_level_1_name=c.path[0][1],
-                        coding_level_2_id=c.path[1][0] if len(c.path) > 1 else None,
-                        coding_level_2_name=c.path[1][1] if len(c.path) > 1 else None,
-                        coding_level_3_id=c.path[2][0] if len(c.path) > 2 else None,
-                        coding_level_3_name=c.path[2][1] if len(c.path) > 2 else None,
-                        confidence_level_1=c.scores[0],
-                        confidence_level_2=c.scores[1] if len(c.scores) > 1 else None,
-                        confidence_level_3=c.scores[2] if len(c.scores) > 2 else None,
-                        confidence_aggregate=c.confidence_aggregate,
-                        explanation=c.explanation,
-                    )
-                    for c in top
-                ),
+                assigned_codes=tuple(assigned_codes),
             )
-        )
+        ]
 
         return CodingAssignmentResultModel(coded_feedback_records=tuple(coded))
 
@@ -1384,6 +1402,7 @@ class Orchestrator:
         tenant_id: str,
         deadline: datetime,
         candidates: list[_ScoredCode],
+        best_rejected: list[_ScoredCode | None],
     ) -> None:
         """Recursively pick and judge codes at one level, descending into children."""
         level_label = f"Code level {level_num}"
@@ -1405,11 +1424,20 @@ class Orchestrator:
                 tenant_id=tenant_id,
                 deadline=deadline,
             )
-            if threshold is not None and judge.score < threshold:
-                continue
             new_path = [*path_ids_names, (node.id, node.name)]
             new_scores = [*accumulated_scores, judge.score]
             new_explanations = [*accumulated_explanations, judge.explanation]
+            if threshold is not None and judge.score < threshold:
+                rejected = _ScoredCode(
+                    path=new_path, scores=new_scores, explanations=new_explanations
+                )
+                if (
+                    best_rejected[0] is None
+                    or rejected.confidence_aggregate
+                    > best_rejected[0].confidence_aggregate
+                ):
+                    best_rejected[0] = rejected
+                continue
             if node.children:
                 await self._traverse_coding_level(
                     feedback_record=feedback_record,
@@ -1423,6 +1451,7 @@ class Orchestrator:
                     tenant_id=tenant_id,
                     deadline=deadline,
                     candidates=candidates,
+                    best_rejected=best_rejected,
                 )
             else:
                 candidates.append(

--- a/tests/services/test_orchestrator.py
+++ b/tests/services/test_orchestrator.py
@@ -12,6 +12,9 @@ from qfa.domain.models import (
     AggregateSummaryResultModel,
     AnalysisRequestModel,
     AnalysisResultModel,
+    CodingAssignmentRequestModel,
+    CodingFramework,
+    CodingNode,
     FeedbackRecordMetadataModel,
     FeedbackRecordModel,
     FeedbackRecordSummaryModel,
@@ -25,6 +28,7 @@ from qfa.domain.models import (
 )
 from qfa.domain.ports import AnonymizationPort, LLMPort
 from qfa.domain.sensitivity_types import SensitivityType
+from qfa.services.coding_classifier import JudgeResponse
 from qfa.services.orchestrator import Orchestrator
 from qfa.settings import OrchestratorSettings
 
@@ -1352,3 +1356,129 @@ class TestAnalyzeAnonymizationOrdering:
         judge_system = fake_llm.calls[1]["system_message"]
         assert sensitive_token not in judge_system
         assert "<PERSON_0>" in judge_system
+
+
+def _make_coding_request(
+    feedback_record=None,
+    root_codes=None,
+    max_codes=5,
+    confidence_threshold=None,
+    tenant_id=TENANT_ID,
+):
+    if feedback_record is None:
+        feedback_record = _make_feedback_record()
+    if root_codes is None:
+        root_codes = [CodingNode(id="code-1", name="Code A")]
+    return CodingAssignmentRequestModel(
+        feedback_record=feedback_record,
+        coding_levels=CodingFramework(root_codes=root_codes),
+        max_codes=max_codes,
+        confidence_threshold=confidence_threshold,
+        tenant_id=tenant_id,
+    )
+
+
+class TestAssignCodesConfidenceThreshold:
+    @pytest.mark.asyncio
+    async def test_all_candidates_rejected_returns_null_codes_with_explanation(
+        self, settings
+    ):
+        """Confirm the near-miss fallback replaces an unexplained empty list.
+
+        When confidence_threshold filters out every candidate, the result
+        carries one null-coded entry explaining the best near-miss rather
+        than an unexplained empty list.
+        """
+        fake_llm = FakeLLMPort(
+            responses=[
+                _make_llm_response(structured='{"selected": [0]}'),
+                _make_llm_response(
+                    structured=JudgeResponse(
+                        score=0.5, explanation="Only loosely related."
+                    )
+                ),
+            ]
+        )
+        orch = Orchestrator(
+            llm=fake_llm,
+            anonymizer=FakeAnonymizer(),
+            settings=settings,
+            llm_timeout_seconds=LLM_TIMEOUT,
+            max_total_tokens=MAX_TOKENS,
+        )
+
+        result = await orch.assign_codes(
+            _make_coding_request(confidence_threshold=0.9), _future_deadline()
+        )
+
+        assigned = result.coded_feedback_records[0].assigned_codes
+        assert len(assigned) == 1
+        code = assigned[0]
+        assert code.coding_level_1_id is None
+        assert code.coding_level_1_name is None
+        assert code.confidence_level_1 is None
+        assert code.confidence_aggregate is None
+        assert "Only loosely related." in code.explanation
+
+    @pytest.mark.asyncio
+    async def test_llm_never_picks_anything_returns_plain_empty_list(self, settings):
+        """Confirm a genuine empty pick is not treated as a near-miss.
+
+        A genuine empty pick (no threshold rejection ever happened) still
+        returns a plain empty list, not a null-coded near-miss entry.
+        """
+        fake_llm = FakeLLMPort(
+            responses=[_make_llm_response(structured='{"selected": []}')]
+        )
+        orch = Orchestrator(
+            llm=fake_llm,
+            anonymizer=FakeAnonymizer(),
+            settings=settings,
+            llm_timeout_seconds=LLM_TIMEOUT,
+            max_total_tokens=MAX_TOKENS,
+        )
+
+        result = await orch.assign_codes(
+            _make_coding_request(confidence_threshold=0.9), _future_deadline()
+        )
+
+        assert result.coded_feedback_records[0].assigned_codes == ()
+
+    @pytest.mark.asyncio
+    async def test_best_near_miss_is_reported_across_multiple_branches(self, settings):
+        """Confirm the higher-scoring rejection wins across branches.
+
+        With two root candidates both rejected, the higher-scoring
+        rejection's explanation wins.
+        """
+        root_codes = [
+            CodingNode(id="code-1", name="Code A"),
+            CodingNode(id="code-2", name="Code B"),
+        ]
+        fake_llm = FakeLLMPort(
+            responses=[
+                _make_llm_response(structured='{"selected": [0, 1]}'),
+                _make_llm_response(
+                    structured=JudgeResponse(score=0.4, explanation="Weak fit A.")
+                ),
+                _make_llm_response(
+                    structured=JudgeResponse(score=0.7, explanation="Weak fit B.")
+                ),
+            ]
+        )
+        orch = Orchestrator(
+            llm=fake_llm,
+            anonymizer=FakeAnonymizer(),
+            settings=settings,
+            llm_timeout_seconds=LLM_TIMEOUT,
+            max_total_tokens=MAX_TOKENS,
+        )
+
+        result = await orch.assign_codes(
+            _make_coding_request(root_codes=root_codes, confidence_threshold=0.9),
+            _future_deadline(),
+        )
+
+        code = result.coded_feedback_records[0].assigned_codes[0]
+        assert "Weak fit B." in code.explanation
+        assert "Weak fit A." not in code.explanation

--- a/tests/services/test_orchestrator.py
+++ b/tests/services/test_orchestrator.py
@@ -1386,8 +1386,8 @@ class TestAssignCodesConfidenceThreshold:
         """Confirm the near-miss fallback replaces an unexplained empty list.
 
         When confidence_threshold filters out every candidate, the result
-        carries one null-coded entry explaining the best near-miss rather
-        than an unexplained empty list.
+        carries one null-coded entry explaining the rejected candidate
+        rather than an unexplained empty list.
         """
         fake_llm = FakeLLMPort(
             responses=[
@@ -1445,11 +1445,11 @@ class TestAssignCodesConfidenceThreshold:
         assert result.coded_feedback_records[0].assigned_codes == ()
 
     @pytest.mark.asyncio
-    async def test_best_near_miss_is_reported_across_multiple_branches(self, settings):
-        """Confirm the higher-scoring rejection wins across branches.
+    async def test_all_rejected_explanations_are_combined_highest_first(self, settings):
+        """Confirm every rejected branch's explanation is surfaced.
 
-        With two root candidates both rejected, the higher-scoring
-        rejection's explanation wins.
+        With two root candidates both rejected, both explanations appear in
+        the combined result, higher-scoring rejection first.
         """
         root_codes = [
             CodingNode(id="code-1", name="Code A"),
@@ -1480,5 +1480,8 @@ class TestAssignCodesConfidenceThreshold:
         )
 
         code = result.coded_feedback_records[0].assigned_codes[0]
+        assert "Weak fit A." in code.explanation
         assert "Weak fit B." in code.explanation
-        assert "Weak fit A." not in code.explanation
+        assert code.explanation.index("Weak fit B.") < code.explanation.index(
+            "Weak fit A."
+        )


### PR DESCRIPTION
Closes #242 
Previously, when confidence_threshold filtered out every candidate at every hierarchy level, assign-codes returned an unexplained empty assigned_codes list, indistinguishable from a malformed LLM response or a genuine "no code applies" pick. Now it returns a single entry with null coding_level_*/confidence_* fields and an explanation describing the highest-scoring rejected candidate.