### PR TITLE
Feat/monitoring2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,12 @@ ARG EMBEDDING_E5_REVISION
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
+# Force stdout/stderr unbuffered. Without this, Python block-buffers output
+# that isn't attached to a TTY (always true in a container), so log lines can
+# sit in a buffer indefinitely instead of reaching the App Service log
+# pipeline in anything like real time.
+ENV PYTHONUNBUFFERED=1
+
 # Model layer first: it's large and rarely changes, so keeping it above the
 # frequently-churning app code means it stays cached (and isn't re-pushed)
 # until the pinned revision changes. Only the default model (e5-base) is

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -4,9 +4,11 @@ Logging, request tracing, and usage reporting.
 
 ## Where logs go
 
-The app writes structured logs to stdout. On Azure App Service these are picked up by the App Service log stream and any attached log sink. Locally, they show up in your terminal.
+The app writes structured logs to stdout/stderr. On Azure App Service these are picked up by the App Service log stream and any attached log sink. Locally, they show up in your terminal.
 
-The log level is controlled by `LOG_LOGLEVEL` for application packages (default `DEBUG`) and `LOG_LOGLEVEL_3RDPARTY` for third-party libraries (default `WARNING`). Both accept either a numeric level or a string (`"debug"`, `"info"`, `"warning"`, `"error"`, `"critical"`).
+Capture depends on **Application Logging (Filesystem)** being on for the App Service — this is the `application_logs { file_system_level = "Information" }` block on `azurerm_linux_web_app.backend.logs` in `infra/app_service.tf`. This is a separate setting from `http_logs` (raw per-request access log) and from the diagnostic setting in `infra/observability.tf` (which ships both into Log Analytics) — without it, the container's stdout/stderr is never captured at all, so there's nothing in the Log stream and nothing for the diagnostic setting to route, regardless of what the app logs or how the diagnostic setting is configured.
+
+The log level is controlled by `LOG_LOGLEVEL` for application packages (default `DEBUG`) and `LOG_LOGLEVEL_3RDPARTY` for third-party libraries (default `WARNING`). Both accept either a numeric level or a string (`"debug"`, `"info"`, `"warning"`, `"error"`, `"critical"`). `file_system_level` above is a second, independent filter on the App Service side — raising it (e.g. to `Warning`) will silently drop lines even if `LOG_LOGLEVEL` would have let them through.
 
 ## Hard prohibitions
 
@@ -211,6 +213,18 @@ as the container runs — they are the authoritative log source today:
   joint query.
 - `AppServiceHTTPLogs` — one row per HTTP request (method, path, status,
   latency), written by the front end regardless of whether the app logs.
+
+For "what API calls have been made and what did they return" specifically, skip
+hand-writing KQL: `infra/observability.tf` provisions a saved query,
+**`qfa-<env>-api-calls-overview`** (category `qfa-monitoring`), against
+`AppServiceHTTPLogs`. Find it in the Log Analytics workspace under **Logs →
+Queries → Saved Queries**, or run it directly:
+
+```kql
+AppServiceHTTPLogs
+| project TimeGenerated, CsMethod, CsUriStem, ScStatus, TimeTaken
+| order by TimeGenerated desc
+```
 
 **Container (console) logs** — the application's own output:
 

--- a/infra/app_service.tf
+++ b/infra/app_service.tf
@@ -74,6 +74,15 @@ resource "azurerm_linux_web_app" "backend" {
   }
 
   logs {
+    # "Application Logging (Filesystem)" in the Portal. This is what captures
+    # the container's stdout/stderr (Python `logging` output) into the
+    # AppServiceConsoleLogs category at all — without it there is nothing for
+    # the Log stream or the diagnostic setting (observability.tf) to show,
+    # regardless of what the app itself logs.
+    application_logs {
+      file_system_level = "Information"
+    }
+
     http_logs {
       file_system {
         retention_in_days = 3

--- a/infra/observability.tf
+++ b/infra/observability.tf
@@ -58,6 +58,21 @@ resource "azurerm_monitor_diagnostic_setting" "app_service" {
   }
 }
 
+# Saved query giving a single place to see every API call and the status code
+# it returned, without hand-writing KQL each time. Shows up in the workspace
+# under Logs -> Queries -> Saved Queries (category below).
+resource "azurerm_log_analytics_saved_search" "api_calls_overview" {
+  name                       = "qfa-${local.env}-api-calls-overview"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  category                   = "qfa-monitoring"
+  display_name               = "QFA API calls overview (method, path, status, duration)"
+  query                      = <<-QUERY
+    AppServiceHTTPLogs
+    | project TimeGenerated, CsMethod, CsUriStem, ScStatus, TimeTaken
+    | order by TimeGenerated desc
+    QUERY
+}
+
 # =============================================================================
 # Alerting
 # =============================================================================

--- a/src/qfa/utils.py
+++ b/src/qfa/utils.py
@@ -56,7 +56,15 @@ def setup_logging(log_settings: LogSettings | None = None) -> None:
         ``LogSettings`` instance is created.
     """
     log_config = log_settings or LogSettings()
-    logging.basicConfig(level=log_config.loglevel_3rdparty, **log_config.basicConfig)
+    # force=True: qfa.main calls configure_azure_monitor() before this runs
+    # whenever APPLICATIONINSIGHTS_CONNECTION_STRING is set (every deployed
+    # environment). That call attaches its own handler to the root logger,
+    # which makes a plain basicConfig() a silent no-op — every log call in the
+    # app would still "succeed" but never reach stdout/stderr, only the
+    # separately-configured OTel export.
+    logging.basicConfig(
+        level=log_config.loglevel_3rdparty, force=True, **log_config.basicConfig
+    )
 
     our_loglevel = log_config.loglevel
     for package in log_config.our_packages:


### PR DESCRIPTION
This solve part of the monitoring issues, but it is not quite fixed yet. It is a start.

## Summary

Makes container logs actually reach Azure, and adds a saved query for browsing API calls.

- **Enable Application Logging (Filesystem)** on the App Service (`infra/app_service.tf`) — without it, the container's stdout/stderr was never captured at all, so nothing reached the Log stream or the diagnostic setting regardless of what the app logged.
- **`PYTHONUNBUFFERED=1`** in the `Dockerfile` — Python block-buffers stdout/stderr when it isn't attached to a TTY (always true in a container), so log lines could sit in a buffer instead of reaching the log pipeline promptly.
- **Force our logging handler in `setup_logging()`** (`src/qfa/utils.py`) — `configure_azure_monitor()` attaches its own handler to the root logger before `setup_logging()` runs in every deployed environment, which made the plain `basicConfig()` call a silent no-op.
- **Saved KQL query** `qfa-<env>-api-calls-overview` (`infra/observability.tf`) against `AppServiceHTTPLogs`, so "what API calls have been made and what did they return" doesn't require hand-writing KQL each time.
- **Docs**: document the Application Logging dependency and the new saved query in `docs/operations/observability.md`.

## Test plan
- [ ] `make test` / `make lint`
- [ ] `terraform plan` against a real environment to confirm the `application_logs` and saved-search resources apply cleanly
- [ ] Deploy and confirm log lines show up in the App Service Log stream / `AppServiceConsoleLogs`
- [ ] See review comment re: verifying `AppTraces` (Application Insights) still receives log lines after the `force=True` change
