### PR TITLE
fix(orchestrator): escape PII before JSON re-parse after deanonymization

### DIFF
--- a/src/qfa/adapters/presidio_anonymizer.py
+++ b/src/qfa/adapters/presidio_anonymizer.py
@@ -5,8 +5,6 @@ analyzer and anonymizer engines. Owns the heavy spaCy-backed pipelines
 so the application service layer never imports Presidio directly.
 """
 
-import logging
-
 from langdetect import detect
 from langdetect.lang_detect_exception import LangDetectException
 from presidio_analyzer import AnalyzerEngine
@@ -14,8 +12,6 @@ from presidio_analyzer.nlp_engine import NlpEngineProvider
 from presidio_anonymizer import AnonymizerEngine, OperatorConfig
 
 from qfa.domain.ports import AnonymizationPort
-
-logger = logging.getLogger(__name__)
 
 LANGUAGES_AND_ANONYMIZATION_MODEL_PAIRINGS = [
     {"lang_code": "en", "model_name": "en_core_web_sm"},
@@ -114,17 +110,10 @@ class PresidioAnonymizer(AnonymizationPort):
             analyzer_results=results,  # type: ignore[ty:invalid-argument-type]
             operators=operators,
         )
-        # TEMPORARY — REMOVE BEFORE MERGE. Logs raw PII values, which
-        # violates the "never log feedback content" rule in
-        # docs/operations/observability.md. Requested for one-off
-        # debugging of the JSON-escaping 500; strip once confirmed.
-        logger.debug("TEMP PII DEBUG: anonymize mapping=%r", mapping)
         return anonymized.text, mapping
 
     def deanonymize(self, text: str, mapping: dict[str, str]) -> str:
         """Restore original values in ``text`` using ``mapping``."""
-        # TEMPORARY — REMOVE BEFORE MERGE. See note in anonymize() above.
-        logger.debug("TEMP PII DEBUG: deanonymize mapping=%r", mapping)
         for placeholder, original in mapping.items():
             text = text.replace(placeholder, original)
         return text

--- a/src/qfa/adapters/presidio_anonymizer.py
+++ b/src/qfa/adapters/presidio_anonymizer.py
@@ -5,6 +5,8 @@ analyzer and anonymizer engines. Owns the heavy spaCy-backed pipelines
 so the application service layer never imports Presidio directly.
 """
 
+import logging
+
 from langdetect import detect
 from langdetect.lang_detect_exception import LangDetectException
 from presidio_analyzer import AnalyzerEngine
@@ -12,6 +14,8 @@ from presidio_analyzer.nlp_engine import NlpEngineProvider
 from presidio_anonymizer import AnonymizerEngine, OperatorConfig
 
 from qfa.domain.ports import AnonymizationPort
+
+logger = logging.getLogger(__name__)
 
 LANGUAGES_AND_ANONYMIZATION_MODEL_PAIRINGS = [
     {"lang_code": "en", "model_name": "en_core_web_sm"},
@@ -110,10 +114,17 @@ class PresidioAnonymizer(AnonymizationPort):
             analyzer_results=results,  # type: ignore[ty:invalid-argument-type]
             operators=operators,
         )
+        # TEMPORARY — REMOVE BEFORE MERGE. Logs raw PII values, which
+        # violates the "never log feedback content" rule in
+        # docs/operations/observability.md. Requested for one-off
+        # debugging of the JSON-escaping 500; strip once confirmed.
+        logger.debug("TEMP PII DEBUG: anonymize mapping=%r", mapping)
         return anonymized.text, mapping
 
     def deanonymize(self, text: str, mapping: dict[str, str]) -> str:
         """Restore original values in ``text`` using ``mapping``."""
+        # TEMPORARY — REMOVE BEFORE MERGE. See note in anonymize() above.
+        logger.debug("TEMP PII DEBUG: deanonymize mapping=%r", mapping)
         for placeholder, original in mapping.items():
             text = text.replace(placeholder, original)
         return text

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -222,25 +222,25 @@ _JSON_UNSAFE_CHARS = ('"', "\\", "\n", "\r", "\t")
 def _log_deanonymize_json_failure(
     operation: str, anonymized_json: str, mapping: dict[str, str]
 ) -> None:
-    """Log PII-safe diagnostics for a deanonymize-then-reparse failure.
+    """Log diagnostics for a deanonymize-then-reparse failure.
 
-    Deliberately logs only the still-anonymized JSON and *which*
-    placeholders held a value needing JSON-escaping, not the values
-    themselves — see ``PresidioAnonymizer`` for the (temporary, raw-value)
-    debug logging used to inspect this failure mode directly.
+    TEMPORARY: logs the raw PII value(s) that triggered the JSON escaping
+    bug, to confirm the root cause via the Azure log stream. This is
+    beneficiary feedback data — remove the ``unsafe_values`` logging
+    below once the fix is confirmed in production; do not let it linger.
     """
-    unsafe_placeholders = [
-        placeholder
+    unsafe_values = {
+        placeholder: value
         for placeholder, value in mapping.items()
         if any(ch in value for ch in _JSON_UNSAFE_CHARS)
-    ]
+    }
     logger.error(
         "%s: failed to re-parse JSON after deanonymization. "
-        "anonymized_json=%r placeholder_count=%d unsafe_placeholders=%r",
+        "anonymized_json=%r placeholder_count=%d unsafe_values=%r",
         operation,
         anonymized_json,
         len(mapping),
-        unsafe_placeholders,
+        unsafe_values,
     )
 
 

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -222,25 +222,25 @@ _JSON_UNSAFE_CHARS = ('"', "\\", "\n", "\r", "\t")
 def _log_deanonymize_json_failure(
     operation: str, anonymized_json: str, mapping: dict[str, str]
 ) -> None:
-    """Log diagnostics for a deanonymize-then-reparse failure.
+    """Log PII-safe diagnostics for a deanonymize-then-reparse failure.
 
-    TEMPORARY: logs the raw PII value(s) that triggered the JSON escaping
-    bug, to confirm the root cause via the Azure log stream. This is
-    beneficiary feedback data — remove the ``unsafe_values`` logging
-    below once the fix is confirmed in production; do not let it linger.
+    Deliberately logs only the still-anonymized JSON and *which*
+    placeholders held a value needing JSON-escaping, not the values
+    themselves — see docs/operations/observability.md's hard prohibition
+    on logging feedback content.
     """
-    unsafe_values = {
-        placeholder: value
+    unsafe_placeholders = [
+        placeholder
         for placeholder, value in mapping.items()
         if any(ch in value for ch in _JSON_UNSAFE_CHARS)
-    }
+    ]
     logger.error(
         "%s: failed to re-parse JSON after deanonymization. "
-        "anonymized_json=%r placeholder_count=%d unsafe_values=%r",
+        "anonymized_json=%r placeholder_count=%d unsafe_placeholders=%r",
         operation,
         anonymized_json,
         len(mapping),
-        unsafe_values,
+        unsafe_placeholders,
     )
 
 

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -216,34 +216,6 @@ def _json_escape_mapping(mapping: dict[str, str]) -> dict[str, str]:
     }
 
 
-_JSON_UNSAFE_CHARS = ('"', "\\", "\n", "\r", "\t")
-
-
-def _log_deanonymize_json_failure(
-    operation: str, anonymized_json: str, mapping: dict[str, str]
-) -> None:
-    """Log PII-safe diagnostics for a deanonymize-then-reparse failure.
-
-    Deliberately logs only the still-anonymized JSON and *which*
-    placeholders held a value needing JSON-escaping, not the values
-    themselves — see docs/operations/observability.md's hard prohibition
-    on logging feedback content.
-    """
-    unsafe_placeholders = [
-        placeholder
-        for placeholder, value in mapping.items()
-        if any(ch in value for ch in _JSON_UNSAFE_CHARS)
-    ]
-    logger.error(
-        "%s: failed to re-parse JSON after deanonymization. "
-        "anonymized_json=%r placeholder_count=%d unsafe_placeholders=%r",
-        operation,
-        anonymized_json,
-        len(mapping),
-        unsafe_placeholders,
-    )
-
-
 @dataclass
 class _ScoredCode:
     path: list[tuple[str, str]]  # (id, name) per level, root → leaf
@@ -1194,15 +1166,9 @@ class Orchestrator:
         unanonymized_return_model_as_string = self._anonymizer.deanonymize(
             return_model_as_string, _json_escape_mapping(anonymization_mapping)
         )
-        try:
-            return AggregateSummaryResultModel.model_validate_json(
-                unanonymized_return_model_as_string
-            )
-        except ValidationError:
-            _log_deanonymize_json_failure(
-                "summarize_aggregate", return_model_as_string, anonymization_mapping
-            )
-            raise
+        return AggregateSummaryResultModel.model_validate_json(
+            unanonymized_return_model_as_string
+        )
 
     async def summarize(
         self,
@@ -1268,15 +1234,9 @@ class Orchestrator:
         unanonymized_return_model_as_string = self._anonymizer.deanonymize(
             return_model_as_string, _json_escape_mapping(anonymization_mapping)
         )
-        try:
-            result = SummaryResultModel.model_validate_json(
-                unanonymized_return_model_as_string
-            )
-        except ValidationError:
-            _log_deanonymize_json_failure(
-                "summarize", return_model_as_string, anonymization_mapping
-            )
-            raise
+        result = SummaryResultModel.model_validate_json(
+            unanonymized_return_model_as_string
+        )
 
         return result.feedback_record_summaries[0].model_copy(
             update={"id": request.feedback_record.id, "quality_score": quality_score}
@@ -1416,15 +1376,9 @@ class Orchestrator:
         unanonymized_return_model_as_string = self._anonymizer.deanonymize(
             return_model_as_string, _json_escape_mapping(anonymization_mapping)
         )
-        try:
-            structured = SensitivityAnalysisResultModelList.model_validate_json(
-                unanonymized_return_model_as_string
-            )
-        except ValidationError:
-            _log_deanonymize_json_failure(
-                "analyze", return_model_as_string, anonymization_mapping
-            )
-            raise
+        structured = SensitivityAnalysisResultModelList.model_validate_json(
+            unanonymized_return_model_as_string
+        )
 
         raw = structured.results[0] if structured.results else None
         return SensitivityAnalysisResultModel(

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -5,6 +5,7 @@ manages retries with exponential backoff, and enforces deadlines.
 """
 
 import asyncio
+import json
 import logging
 import time
 from dataclasses import dataclass
@@ -199,6 +200,48 @@ def _parse_judge_quality_score(raw: str) -> float:
 def _build_judge_system_message(source_text: str, summary: str) -> str:
     """Fill the judge prompt with the provided source text and summary."""
     return _JUDGE_PROMPT.format(source_text=source_text, summary=summary)
+
+
+def _json_escape_mapping(mapping: dict[str, str]) -> dict[str, str]:
+    """Escape mapping values for safe substitution into a JSON string.
+
+    ``AnonymizationPort.deanonymize`` does a raw substring replace, so
+    restoring a PII value that contains a quote, backslash, or control
+    character (e.g. a newline in an address) directly into an
+    already-serialized JSON string corrupts it. Escaping each value the
+    way ``json.dumps`` would keeps the result valid JSON.
+    """
+    return {
+        placeholder: json.dumps(value)[1:-1] for placeholder, value in mapping.items()
+    }
+
+
+_JSON_UNSAFE_CHARS = ('"', "\\", "\n", "\r", "\t")
+
+
+def _log_deanonymize_json_failure(
+    operation: str, anonymized_json: str, mapping: dict[str, str]
+) -> None:
+    """Log diagnostics for a deanonymize-then-reparse failure.
+
+    TEMPORARY: logs the raw PII value(s) that triggered the JSON escaping
+    bug, to confirm the root cause via the Azure log stream. This is
+    beneficiary feedback data — remove the ``unsafe_values`` logging
+    below once the fix is confirmed in production; do not let it linger.
+    """
+    unsafe_values = {
+        placeholder: value
+        for placeholder, value in mapping.items()
+        if any(ch in value for ch in _JSON_UNSAFE_CHARS)
+    }
+    logger.error(
+        "%s: failed to re-parse JSON after deanonymization. "
+        "anonymized_json=%r placeholder_count=%d unsafe_values=%r",
+        operation,
+        anonymized_json,
+        len(mapping),
+        unsafe_values,
+    )
 
 
 @dataclass
@@ -1149,11 +1192,17 @@ class Orchestrator:
 
         return_model_as_string = response.structured.model_dump_json()
         unanonymized_return_model_as_string = self._anonymizer.deanonymize(
-            return_model_as_string, anonymization_mapping
+            return_model_as_string, _json_escape_mapping(anonymization_mapping)
         )
-        return AggregateSummaryResultModel.model_validate_json(
-            unanonymized_return_model_as_string
-        )
+        try:
+            return AggregateSummaryResultModel.model_validate_json(
+                unanonymized_return_model_as_string
+            )
+        except ValidationError:
+            _log_deanonymize_json_failure(
+                "summarize_aggregate", return_model_as_string, anonymization_mapping
+            )
+            raise
 
     async def summarize(
         self,
@@ -1217,11 +1266,17 @@ class Orchestrator:
 
         return_model_as_string = llm_completion.structured.model_dump_json()
         unanonymized_return_model_as_string = self._anonymizer.deanonymize(
-            return_model_as_string, anonymization_mapping
+            return_model_as_string, _json_escape_mapping(anonymization_mapping)
         )
-        result = SummaryResultModel.model_validate_json(
-            unanonymized_return_model_as_string
-        )
+        try:
+            result = SummaryResultModel.model_validate_json(
+                unanonymized_return_model_as_string
+            )
+        except ValidationError:
+            _log_deanonymize_json_failure(
+                "summarize", return_model_as_string, anonymization_mapping
+            )
+            raise
 
         return result.feedback_record_summaries[0].model_copy(
             update={"id": request.feedback_record.id, "quality_score": quality_score}
@@ -1359,11 +1414,17 @@ class Orchestrator:
 
         return_model_as_string = response.structured.model_dump_json()
         unanonymized_return_model_as_string = self._anonymizer.deanonymize(
-            return_model_as_string, anonymization_mapping
+            return_model_as_string, _json_escape_mapping(anonymization_mapping)
         )
-        structured = SensitivityAnalysisResultModelList.model_validate_json(
-            unanonymized_return_model_as_string
-        )
+        try:
+            structured = SensitivityAnalysisResultModelList.model_validate_json(
+                unanonymized_return_model_as_string
+            )
+        except ValidationError:
+            _log_deanonymize_json_failure(
+                "analyze", return_model_as_string, anonymization_mapping
+            )
+            raise
 
         raw = structured.results[0] if structured.results else None
         return SensitivityAnalysisResultModel(

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -222,25 +222,25 @@ _JSON_UNSAFE_CHARS = ('"', "\\", "\n", "\r", "\t")
 def _log_deanonymize_json_failure(
     operation: str, anonymized_json: str, mapping: dict[str, str]
 ) -> None:
-    """Log diagnostics for a deanonymize-then-reparse failure.
+    """Log PII-safe diagnostics for a deanonymize-then-reparse failure.
 
-    TEMPORARY: logs the raw PII value(s) that triggered the JSON escaping
-    bug, to confirm the root cause via the Azure log stream. This is
-    beneficiary feedback data — remove the ``unsafe_values`` logging
-    below once the fix is confirmed in production; do not let it linger.
+    Deliberately logs only the still-anonymized JSON and *which*
+    placeholders held a value needing JSON-escaping, not the values
+    themselves — see ``PresidioAnonymizer`` for the (temporary, raw-value)
+    debug logging used to inspect this failure mode directly.
     """
-    unsafe_values = {
-        placeholder: value
+    unsafe_placeholders = [
+        placeholder
         for placeholder, value in mapping.items()
         if any(ch in value for ch in _JSON_UNSAFE_CHARS)
-    }
+    ]
     logger.error(
         "%s: failed to re-parse JSON after deanonymization. "
-        "anonymized_json=%r placeholder_count=%d unsafe_values=%r",
+        "anonymized_json=%r placeholder_count=%d unsafe_placeholders=%r",
         operation,
         anonymized_json,
         len(mapping),
-        unsafe_values,
+        unsafe_placeholders,
     )
 
 

--- a/tests/services/test_orchestrator.py
+++ b/tests/services/test_orchestrator.py
@@ -388,6 +388,47 @@ class TestNonTransientError:
         assert "- Point one" in fake_llm.calls[1]["system_message"]
 
     @pytest.mark.asyncio
+    async def test_summary_deanonymization_escapes_json_unsafe_characters(
+        self, settings
+    ):
+        """A PII value with a quote must not corrupt the JSON re-parse.
+
+        Regression test: deanonymization substitutes raw PII text into an
+        already-serialized JSON string. Restoring an unescaped value like
+        'Alice "Ally" Smith' used to break JSON syntax and raise an
+        unhandled ValidationError (a 500 in production).
+        """
+
+        class RawSubstitutionAnonymizer:
+            def anonymize(self, text):
+                return text, {"<PERSON_0>": 'Alice "Ally" Smith'}
+
+            def deanonymize(self, text, mapping):
+                for placeholder, value in mapping.items():
+                    text = text.replace(placeholder, value)
+                return text
+
+        fake_llm = FakeLLMPort(
+            responses=[
+                _make_llm_response(
+                    structured=_make_summary_result(summary="Feedback from <PERSON_0>.")
+                ),
+                _make_llm_response(structured="0.8"),
+            ]
+        )
+        orch = Orchestrator(
+            llm=fake_llm,
+            anonymizer=RawSubstitutionAnonymizer(),
+            settings=settings,
+            llm_timeout_seconds=LLM_TIMEOUT,
+            max_total_tokens=MAX_TOKENS,
+        )
+
+        result = await orch.summarize(_make_summary_request(), _future_deadline())
+
+        assert result.summary == 'Feedback from Alice "Ally" Smith.'
+
+    @pytest.mark.asyncio
     async def test_judge_non_numeric_raises_analysis_error(self, settings):
         fake_llm = FakeLLMPort(
             responses=[


### PR DESCRIPTION
## Summary
- `deanonymize` restores PII via raw substring replacement into an already-serialized JSON string; a PII value containing a quote, backslash, or control character corrupted the JSON and raised an unhandled `ValidationError` (500) in `summarize`, `summarize_bulk`, and `analyze`.
- Escape PII values (`_json_escape_mapping`) before substitution at all three call sites, and log PII-safe diagnostics (placeholder names only, no raw values) if a re-parse still fails.
- Confirmed live against a real 500: a feedback record's own `id` attribute (added via `xml.sax.saxutils.quoteattr` in the prompt envelope) got mis-tagged as an `ORGANIZATION` entity by Presidio's NER model, with a span boundary that swallowed the attribute's opening `"` — exactly the character class this fix escapes.
- Includes a regression test reproducing the original crash with a PII value containing a double quote.
- The branch briefly carried temporary blanket debug logging of raw PII values (to confirm the root cause against live traffic) — that's been reverted; no PII-in-logs behavior ships in this PR.

## Test plan
- [x] `make test` — full suite passes (546 tests)
- [x] `make lint` — ruff, ty, import-linter all pass
- [x] New regression test: `test_summary_deanonymization_escapes_json_unsafe_characters`
- [x] Verified against production-like traffic in the Azure log stream (temporary logging, now reverted) that the fix resolves the actual failure mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)