### PR TITLE
feat(api): double all request deadlines and LLM timeouts

### DIFF
--- a/docs/architecture/04-crosscutting.md
+++ b/docs/architecture/04-crosscutting.md
@@ -72,9 +72,9 @@ Both adapters depend on `qfa.services.call_context`; neither depends on the othe
 
 | Layer | Concern | Mechanism |
 |---|---|---|
-| Route handler | Per-request deadline | `deadline = now(UTC) + 120s`, passed as an absolute `datetime` into the orchestrator |
+| Route handler | Per-request deadline | `deadline = now(UTC) + 240s`, passed as an absolute `datetime` into the orchestrator |
 | Orchestrator | Deadline check | Before each LLM call: if remaining time is negative, raise {py:exc}`~qfa.domain.errors.AnalysisTimeoutError` |
-| Adapter ({py:class}`~qfa.adapters.llm_client.LiteLLMClient`) | Retry on transient errors | `tenacity.retry` with exponential backoff (1s→10s, 60s budget) for {py:exc}`~qfa.domain.errors.LLMTimeoutError` and {py:exc}`~qfa.domain.errors.LLMRateLimitError` |
+| Adapter ({py:class}`~qfa.adapters.llm_client.LiteLLMClient`) | Retry on transient errors | `tenacity.retry` with exponential backoff (1s→10s, 120s budget) for {py:exc}`~qfa.domain.errors.LLMTimeoutError` and {py:exc}`~qfa.domain.errors.LLMRateLimitError` |
 | Adapter ({py:class}`~qfa.adapters.llm_client.LiteLLMClient`) | Per-call timeout | Passed through to `litellm.acompletion(timeout=…)` |
 | Adapter ({py:class}`~qfa.adapters.llm_client.LiteLLMClient`) | Token budget guard | Estimates `len(text) / chars_per_token`; raises {py:exc}`~qfa.domain.errors.FeedbackTooLargeError` if over `LLM_MAX_TOTAL_TOKENS` |
 

--- a/docs/development/implementing-a-new-endpoint.md
+++ b/docs/development/implementing-a-new-endpoint.md
@@ -212,7 +212,7 @@ async def classify(
 
     An empty ``content`` returns a 200 empty result with no LLM call.
     """
-    deadline = datetime.now(UTC) + timedelta(seconds=120)
+    deadline = datetime.now(UTC) + timedelta(seconds=240)
 
     if not body.feedback_record.content:
         return ApiClassifyResponse(label="", confidence=None,

--- a/docs/operations/settings-reference.md
+++ b/docs/operations/settings-reference.md
@@ -12,7 +12,7 @@ Every environment variable the app reads. Settings are loaded by `pydantic-setti
 | `LLM_API_KEY` | **yes** | — | Provider API key. Stored as `SecretStr`. |
 | `LLM_API_BASE` | only some providers | `""` | E.g. `https://<resource>.openai.azure.com/` for Azure OpenAI. |
 | `LLM_API_VERSION` | only some providers | `""` | API version where the provider expects one. |
-| `LLM_TIMEOUT_SECONDS` | no | `115.0` | Per-*attempt* LLM-call timeout. A single call retries transient failures (timeout, rate-limit) up to `3×` this budget; the orchestrator sizes the per-attempt timeout against the request deadline so the worst-case retry sequence still fits. |
+| `LLM_TIMEOUT_SECONDS` | no | `230.0` | Per-*attempt* LLM-call timeout. A single call retries transient failures (timeout, rate-limit) up to `3×` this budget; the orchestrator sizes the per-attempt timeout against the request deadline so the worst-case retry sequence still fits. |
 | `LLM_MAX_TOTAL_TOKENS` | no | `100000` | Token budget guard. Estimated as `len(text) / LLM_CHARS_PER_TOKEN`. |
 | `LLM_CHARS_PER_TOKEN` | no | `4` | Conversion ratio used by the token budget guard. |
 

--- a/src/qfa/adapters/llm_client.py
+++ b/src/qfa/adapters/llm_client.py
@@ -240,7 +240,7 @@ class LiteLLMClient(LLMPort):
         user_message: str,
         tenant_id: str,
         response_model: type[T_Response],
-        timeout: float = 20.0,
+        timeout: float = 40.0,
     ) -> LLMResponse[T_Response]:
         """Send a completion request via LiteLLM, retrying transient failures.
 

--- a/src/qfa/api/routes.py
+++ b/src/qfa/api/routes.py
@@ -185,7 +185,7 @@ async def analyze_bulk(
         populated for both modes whenever metadata permits; ``confidence``
         is populated only for ``hierarchical`` mode.
     """
-    deadline = datetime.now(UTC) + timedelta(seconds=600)
+    deadline = datetime.now(UTC) + timedelta(seconds=1200)
 
     records = _drop_empty_records(body.feedback_records)
     if not records:
@@ -283,7 +283,7 @@ async def summarize_bulk(
     ApiSummarizeBulkResponse
         A single summary with themes ordered by frequency across all feedback records.
     """
-    deadline = datetime.now(UTC) + timedelta(seconds=120)
+    deadline = datetime.now(UTC) + timedelta(seconds=240)
 
     records = _drop_empty_records(body.feedback_records)
     if not records:
@@ -355,7 +355,7 @@ async def summarize(
     ApiSummarizeResponse
         The per-feedback-record titles and summaries.
     """
-    deadline = datetime.now(UTC) + timedelta(seconds=120)
+    deadline = datetime.now(UTC) + timedelta(seconds=240)
 
     if not body.feedback_record.content:
         # Nothing to summarize: return a 200 empty summary that still
@@ -412,7 +412,7 @@ async def assign_codes(
     ``explanation`` combines every rejected candidate's explanation,
     highest-scoring first.
     """
-    deadline = datetime.now(UTC) + timedelta(seconds=120)
+    deadline = datetime.now(UTC) + timedelta(seconds=240)
 
     if not body.feedback_record.content:
         # No content to code: return a 200 empty assignment without an LLM
@@ -493,7 +493,7 @@ async def detect_sensitive(
     ApiDetectSensitiveResponse
         Sensitivity rating for each submitted feedback item.
     """
-    deadline = datetime.now(UTC) + timedelta(seconds=120)
+    deadline = datetime.now(UTC) + timedelta(seconds=240)
 
     if not body.feedback_record.content:
         # No content to evaluate: report not-sensitive without an LLM call

--- a/src/qfa/settings.py
+++ b/src/qfa/settings.py
@@ -79,7 +79,7 @@ class LLMSettings(BaseSettings):
     api_key: SecretStr = Field(default=...)  # required, no default
     api_base: str = ""
     api_version: str = ""
-    timeout_seconds: float = 115.0
+    timeout_seconds: float = 230.0
     max_total_tokens: int = 100_000
     chars_per_token: int = 4
 

--- a/tests/services/test_orchestrator.py
+++ b/tests/services/test_orchestrator.py
@@ -185,7 +185,7 @@ class FakeLLMPort(LLMPort):
         user_message,
         tenant_id,
         response_model=str,
-        timeout=20.0,
+        timeout=40.0,
     ):
         self.calls.append(
             {

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -37,7 +37,7 @@ class TestLLMSettings:
     def test_default_timeout_seconds(self, monkeypatch):
         monkeypatch.setenv("LLM_API_KEY", "sk-test")
         settings = LLMSettings()
-        assert settings.timeout_seconds == 115.0
+        assert settings.timeout_seconds == 230.0
 
     def test_default_max_total_tokens(self, monkeypatch):
         monkeypatch.setenv("LLM_API_KEY", "sk-test")


### PR DESCRIPTION
Closes #239

## Summary
- Doubled the per-request deadline on every endpoint: `/v1/analyze-bulk` (+hierarchical) 600s -> 1200s; `/v1/summarize-bulk`, `/v1/summarize`, `/v1/assign-codes`, `/v1/detect-sensitive` 120s -> 240s.
- Doubled `LLM_TIMEOUT_SECONDS` (115.0 -> 230.0) — the per-attempt cap that actually binds for `analyze-bulk`'s deadline (`remaining / 3` exceeds it there), so its per-attempt timeout doubles too, not just the overall deadline.
- Doubled the hardcoded default in `LiteLLMClient.complete()` (20.0 -> 40.0) — used only by `assign_codes`' internal per-level pick/judge calls, which don't derive a timeout from the request deadline the way every other call site does.
- Updated the doc pages that documented the old numbers (`docs/architecture/04-crosscutting.md`, `docs/operations/settings-reference.md`, `docs/development/implementing-a-new-endpoint.md`). Left the dated architecture-review snapshots untouched since they're historical records, not living docs.

## Test plan
- [x] `make test` — full suite passes (545 tests)
- [x] `make lint` — ruff, ty, import-linter all pass
- [x] Updated `test_settings.py`/`test_orchestrator.py` assertions to the new default values

🤖 Generated with [Claude Code](https://claude.com/claude-code)