### PR TITLE
fix(github): wire Terraform apply into the promotion pipelines

### DIFF
--- a/.github/workflows/promote-to-dev.yaml
+++ b/.github/workflows/promote-to-dev.yaml
@@ -22,7 +22,17 @@ permissions:
   id-token: write
 
 jobs:
+  terraform:
+    uses: ./.github/workflows/terraform.yaml
+    with:
+      environment: dev
+      command: apply
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
   deploy:
+    needs: terraform
     uses: ./.github/workflows/_deploy-release.yaml
     with:
       release_tag: ${{ inputs.release_tag }}

--- a/.github/workflows/promote-to-prd.yaml
+++ b/.github/workflows/promote-to-prd.yaml
@@ -53,9 +53,18 @@ jobs:
             exit 1
           fi
           echo "$TAG is a published final release — OK to promote to prd."
-
-  deploy:
+  terraform:
+    uses: ./.github/workflows/terraform.yaml
     needs: verify
+    with:
+      environment: prd
+      command: apply
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+  deploy:
+    needs: terraform
     uses: ./.github/workflows/_deploy-release.yaml
     with:
       release_tag: ${{ inputs.release_tag }}

--- a/.github/workflows/promote-to-staging.yaml
+++ b/.github/workflows/promote-to-staging.yaml
@@ -53,9 +53,18 @@ jobs:
             exit 1
           fi
           echo "$TAG is a published release — OK to promote to staging."
-
-  deploy:
+  terraform:
     needs: verify
+    uses: ./.github/workflows/terraform.yaml
+    with:
+      environment: staging
+      command: apply
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+  deploy:
+    needs: terraform
     uses: ./.github/workflows/_deploy-release.yaml
     with:
       release_tag: ${{ inputs.release_tag }}

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -24,6 +24,16 @@ on:
     paths:
       - "infra/**"
   pull_request:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Target environment (Terraform workspace)"
+        type: string
+        default: dev
+      command:
+        description: "Terraform command to run (plan or apply)"
+        type: string
+        default: plan
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## Summary
- Made `terraform.yaml` callable as a reusable workflow (`workflow_call`) alongside its existing `push`/`pull_request`/`workflow_dispatch` triggers, exposing `environment`/`command` as string inputs (no enum constraint at this trigger's schema level — unlike the `workflow_dispatch` dropdown).
- Wired a `terraform` job (`environment: <env>`, `command: apply`) into `promote-to-dev.yaml`, `promote-to-staging.yaml`, and `promote-to-prd.yaml`, running before the existing `deploy` job (`needs:`) so infra changes land before the app image is repointed.
- Each `terraform` job restates the permissions the called workflow needs (`contents: read`, `id-token: write`) and adds `secrets: inherit` so `TEAMS_ALERTS_WEBHOOK_URL` reaches it — neither propagates automatically to a called reusable workflow.
- `promote-to-staging.yaml`'s `terraform` job runs after `verify` (matching `promote-to-prd.yaml`'s existing gate ordering), using the `staging` environment/workspace name consistently with the rest of the file.

## Test plan
- [ ] Run **Promote to dev** with "Use workflow from" set to this branch, confirm the `terraform` job actually executes `apply` against the `dev` workspace (not skipped) before `deploy` runs.
- [ ] Same dry run for **Promote to staging** (workspace `staging`) and **Promote to prd** (workspace `prd`, subject to the `prd` environment's required-reviewer gate).
- [ ] Confirm `terraform apply` reports "no changes" when there's nothing to apply (idempotency check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)