### PR TITLE
assign codes: always explain why no code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,5 @@ config
 # See https://github.com/mariushelf/copier-devcontainer
 /.devcontainer/
 /.envrc
+.graphify-out
+

--- a/.gitignore
+++ b/.gitignore
@@ -200,5 +200,5 @@ config
 # See https://github.com/mariushelf/copier-devcontainer
 /.devcontainer/
 /.envrc
-.graphify-out
+graphify-out/
 

--- a/docs/integrations/espo-crm.md
+++ b/docs/integrations/espo-crm.md
@@ -40,6 +40,8 @@ Each of the three calls tracks its own status field on the feedback record, movi
 | `assign-codes` | `autoCodingStatus` | `autoCodingErrorCode`, `autoCodingErrorMessage` |
 | `detect-sensitive` | `autoSensitiveStatus` | `autoSensitiveErrorCode`, `autoSensitiveErrorMessage` |
 
+The `assign-codes` step copies `assigned_codes.0.explanation` into `autoCodingExplanation`. A record can legitimately come back with no code applied while `autoCodingStatus` is still `completed` — that is a successful call, not an error, so it sets none of the error fields. The API guarantees that `assigned_codes` is never empty, so in that case `autoCodingExplanation` holds a message beginning with `NO CODING APPLIED.` explaining why. See the [REST API reference](../rest-api/index.md) for the exact wording.
+
 ### Insight saving script
 
 The insight call tracks a single status field, `autoInsightStatus`, moving through the same `processing` → `completed` (or `failed`) states, alongside `autoInsightErrorCode` and `autoInsightErrorMessage` on failure.

--- a/docs/rest-api/index.md
+++ b/docs/rest-api/index.md
@@ -59,9 +59,26 @@ the single-pass response too.
 
 Per-record inference endpoints (`/v1/summarize`, `/v1/assign-codes`, `/v1/detect-sensitive`) accept a single `feedback_record` and return one result object, unlike bulk endpoints that accept multiple records and return aggregated output.
 
-Empty `content` is accepted on every endpoint and never causes a 422. A record with empty content carries no information, so it is dropped (bulk) or short-circuited to a 200 empty result with no LLM call (per-record) — see each endpoint's reference for the exact empty-result shape. This keeps a single blank EspoCRM description from silently failing a whole request (issue #138).
+Empty `content` is accepted on every endpoint and never causes a 422. A record with empty content carries no information, so it is dropped (bulk) or short-circuited to a 200 with no LLM call (per-record) — see each endpoint's reference for the exact result shape. This keeps a single blank EspoCRM description from silently failing a whole request (issue #138).
 
-`POST /v1/assign-codes` accepts an optional `confidence_threshold`; codes whose judge score falls below it are filtered out. If every candidate at every hierarchy level is filtered out this way, the response is a 200 with a single `assigned_codes` entry whose `coding_level_*`/`confidence_*` fields are `null` and whose `explanation` combines every rejected candidate's explanation (highest-scoring first) — instead of an unexplained empty list.
+`POST /v1/assign-codes` accepts an optional `confidence_threshold`; codes whose judge score falls below it are filtered out. Its `assigned_codes` list is never empty: whenever no code is applied — because the content was empty, because no candidate reached the threshold, or because nothing in the framework was judged relevant — the response is a 200 with exactly one entry whose `coding_level_*`/`confidence_*` fields are `null` and whose `explanation` begins with the line `NO CODING APPLIED.` followed by the reason. A client therefore always has something to show the user instead of an unexplained empty list.
+
+When the threshold is what blocked coding, the explanation names the threshold as a percentage and lists the closest near misses (at most three, highest-scoring first, each with its decisive level's reasoning), then counts any remainder:
+
+```text
+NO CODING APPLIED.
+No code reached the 10% confidence threshold, so this record needs human review.
+
+Shelter > Repairs > Roofing — 4%
+  No mention of roof damage; the feedback concerns rent costs.
+
+Water — 3%
+  No reference to water access.
+
+5 further codes scored below 3%.
+```
+
+These explanations are English only, regardless of the language of the feedback.
 
 ## Hyperlinking feedback records
 

--- a/spec/issue-256.md
+++ b/spec/issue-256.md
@@ -1,0 +1,80 @@
+## Spec
+
+**What:** Make `POST /v1/assign-codes` always return at least one `assigned_codes` entry
+when no code is applied, carrying a human-readable explanation that leads with
+`NO CODING APPLIED.`
+
+Three code paths currently end with no code assigned, and only one of them explains itself:
+
+| # | Trigger | Today returns | Explanation? |
+|---|---|---|---|
+| 1 | Empty `content` — `src/qfa/api/routes.py:424` (issue #138) | `[]` | none |
+| 2 | Every candidate below `confidence_threshold` — `src/qfa/services/orchestrator.py:1367` | one null entry | combined rejections, unlabelled |
+| 3 | Nothing selected at any level — `src/qfa/services/orchestrator.py:1374` | `[]` | none |
+
+Cases 1 and 3 leave EspoCRM with nothing at all to display: `4_1_assign_codes.php` reads
+`assigned_codes.0.explanation`, gets null, and still sets `autoCodingStatus = 'completed'`.
+Case 2 does deliver text, but it is unlabelled and hard to read.
+
+This ticket unifies all three behind one contract and reformats the message.
+
+**Why:** Users see codes silently missing in EspoCRM with no indication why (parent #255).
+Case 2's explanation already reaches Espo via `autoCodingExplanation`, so improving that text
+is immediately visible to users without any EspoCRM change. Cases 1 and 3 send nothing, so no
+amount of formatting helps until they also return an entry.
+
+### Target format (case 2)
+
+```
+NO CODING APPLIED.
+No code reached the 10% confidence threshold, so this record needs human review.
+
+Shelter > Repairs > Roofing — 4%
+  No mention of roof damage; the feedback concerns rent costs.
+
+Water — 3%
+  No reference to water access.
+
+Food Security — 2%
+  Concerns housing, not food.
+
+5 further codes scored below 2%.
+```
+
+Cases 1 and 3 use the same `NO CODING APPLIED.` lead with a case-specific second line and no
+candidate list.
+
+### Notes for the implementer
+
+- `_combine_rejected_explanations` (`orchestrator.py:265`) currently takes only `rejected`.
+  The threshold is available at the call site (`orchestrator.py:1370`) and must be threaded in.
+- A rejected candidate has exactly one sub-threshold level — the traversal `continue`s on the
+  first failure (`orchestrator.py:1503-1508`). So the last accumulated score is always the
+  minimum, and the decisive level is unambiguous.
+- When `confidence_threshold` is `None` nothing is ever rejected, so case 2 cannot occur
+  without a real threshold value. The percentage in the lead line always has a value.
+- English only. `ApiAssignCodesRequest` has no `output_language` field and this ticket does not
+  add one; localization is explicitly out of scope.
+- Keep the message in the existing `explanation` string. Do **not** add a `pretty_output`
+  property to `ApiAssignCodesResponse` — that would require a matching EspoCRM script change
+  and is out of scope here.
+
+## Acceptance criteria
+
+- [ ] `assigned_codes` is never an empty list; when no code is applied it contains exactly one
+      entry with null `coding_level_*` / `confidence_*` fields and a non-empty `explanation`
+- [ ] Every no-code `explanation` begins with the literal line `NO CODING APPLIED.`
+- [ ] Case 1 (empty `content`) yields an explanation stating the feedback text was empty;
+      `tests/api/test_routes.py::test_assign_codes_empty_content_returns_no_codes` is updated
+      from asserting `== []` to the new shape
+- [ ] Case 2 (below threshold) yields a lead line naming the threshold as a whole percentage
+- [ ] Case 3 (no candidate selected) yields an explanation stating that no code in the
+      framework was judged relevant
+- [ ] Confidence values render as whole percentages, not `0.00`–`1.00` decimals
+- [ ] Each listed candidate shows only its decisive (final, lowest-scoring) level's judge
+      explanation, not one line per hierarchy level
+- [ ] At most 3 rejected candidates are listed, highest-scoring first, followed by a single
+      line counting the remainder; that count line is absent when 3 or fewer were rejected
+- [ ] `_combine_rejected_explanations` receives the confidence threshold from its call site
+- [ ] Docstrings in `routes.py` and `orchestrator.py` describing the #138 empty-list contract
+      are reworded to match the new behaviour

--- a/src/qfa/api/routes.py
+++ b/src/qfa/api/routes.py
@@ -44,7 +44,10 @@ from qfa.domain.models import (
     TenantApiKey,
 )
 from qfa.domain.usage_models import CallContext, Operation
-from qfa.services.orchestrator import Orchestrator
+from qfa.services.orchestrator import (
+    NO_CODING_EMPTY_CONTENT_EXPLANATION,
+    Orchestrator,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -407,21 +410,33 @@ async def assign_codes(
 ) -> ApiAssignCodesResponse:
     """Assign codes via iterative LLM picks at each level of the framework.
 
-    If the record's ``content`` is empty the response is a 200 with an empty
-    ``assigned_codes`` list, returned without an LLM call (issue #138).
-
-    If every candidate is filtered out by ``confidence_threshold``, the
-    response is a 200 with a single ``assigned_codes`` entry whose
+    ``assigned_codes`` is never an empty list. Whenever no code is applied
+    the response is a 200 carrying exactly one entry whose
     ``coding_level_*``/``confidence_*`` fields are null and whose
-    ``explanation`` combines every rejected candidate's explanation,
-    highest-scoring first.
+    ``explanation`` begins with the line ``NO CODING APPLIED.`` followed by
+    the reason (#256), so a client always has something to show the user:
+
+    - the record's ``content`` is empty — returned without an LLM call
+      (issue #138);
+    - every candidate was filtered out by ``confidence_threshold`` — the
+      explanation names the threshold and lists the closest near misses,
+      highest-scoring first;
+    - no code was selected at any level — the explanation states that
+      nothing in the framework was judged relevant.
+
+    The explanation is English only, regardless of the feedback language.
     """
     deadline = datetime.now(UTC) + timedelta(seconds=240)
 
     if not body.feedback_record.content:
-        # No content to code: return a 200 empty assignment without an LLM
-        # call (issue #138).
-        return ApiAssignCodesResponse(assigned_codes=[])
+        # No content to code: return a 200 without an LLM call (issue #138),
+        # explaining the empty text rather than returning a bare empty list
+        # the client would have to interpret (#256).
+        return ApiAssignCodesResponse(
+            assigned_codes=[
+                ApiAssignedCode(explanation=NO_CODING_EMPTY_CONTENT_EXPLANATION)
+            ]
+        )
 
     domain_request = CodingAssignmentRequestModel(
         feedback_record=FeedbackRecordModel(

--- a/src/qfa/api/schemas.py
+++ b/src/qfa/api/schemas.py
@@ -846,9 +846,11 @@ class ApiAssignedCode(BaseModel):
     explanation: str = Field(
         description=(
             "Judge explanation combining reasoning from all hierarchy "
-            "levels. When no code cleared the confidence threshold, this "
-            "combines every rejected candidate's explanation instead, "
-            "highest-scoring first."
+            "levels. When no code was applied, this instead begins with "
+            "the line 'NO CODING APPLIED.' followed by the reason — empty "
+            "feedback text, no candidate reaching the confidence threshold "
+            "(listing the closest near misses), or nothing in the "
+            "framework being judged relevant. English only."
         )
     )
 

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -261,17 +261,85 @@ class _ScoredCode:
             for i, (score, expl) in enumerate(zip(self.scores, self.explanations))
         )
 
+    @property
+    def decisive_explanation(self) -> str:
+        """The judge explanation for the level that decided this candidate.
 
-def _combine_rejected_explanations(rejected: list[_ScoredCode]) -> str:
-    """Join every threshold-rejected candidate's explanation into one string.
+        ``_traverse_coding_level`` stops descending at the first level that
+        falls below the threshold, so for a *rejected* candidate the last
+        accumulated level is both its lowest-scoring one and the reason it
+        was dropped. The levels before it passed and would only add noise
+        to a message whose whole point is "why was nothing applied".
+        """
+        return self.explanations[-1]
 
-    Highest-scoring rejection first, each labelled with its hierarchy path
-    so a reader can tell which candidate an explanation belongs to.
+
+NO_CODING_LEAD = "NO CODING APPLIED."
+"""Literal first line of every explanation returned when no code is applied.
+
+EspoCRM surfaces ``assigned_codes.0.explanation`` verbatim as
+``autoCodingExplanation``, so this line is what a user reads first when a
+record comes back uncoded (#256).
+"""
+
+NO_CODING_EMPTY_CONTENT_EXPLANATION = (
+    f"{NO_CODING_LEAD}\nThe feedback text was empty, so there was nothing to code."
+)
+"""Explanation for a record whose ``content`` is empty (issue #138)."""
+
+NO_CODING_NOTHING_RELEVANT_EXPLANATION = (
+    f"{NO_CODING_LEAD}\nNo code in the framework was judged relevant to this feedback."
+)
+"""Explanation for when the LLM selected nothing at any hierarchy level."""
+
+_MAX_LISTED_REJECTIONS = 3
+"""How many near-miss candidates to spell out before collapsing to a count."""
+
+
+def _as_whole_percentage(confidence: float) -> str:
+    """Render a 0-1 confidence as a whole percentage (``0.04`` -> ``"4%"``).
+
+    Non-technical EspoCRM readers see these numbers directly, and a
+    ``0.04`` next to a "Level 2" label reads as noise where "4%" reads as
+    a judgement.
+    """
+    return f"{round(confidence * 100)}%"
+
+
+def _combine_rejected_explanations(
+    rejected: list[_ScoredCode], threshold: float
+) -> str:
+    """Explain in prose why every candidate was rejected by the threshold.
+
+    Leads with :data:`NO_CODING_LEAD` and a sentence naming the threshold,
+    then lists at most :data:`_MAX_LISTED_REJECTIONS` candidates —
+    highest-scoring (closest to being applied) first — as a
+    ``path — percentage`` header over the decisive level's explanation.
+    Any remainder collapses into a single count line rather than an
+    unbounded wall of text.
     """
     ordered = sorted(rejected, key=lambda c: c.confidence_aggregate, reverse=True)
-    return "\n\n".join(
-        f"{' > '.join(name for _, name in c.path)}:\n{c.explanation}" for c in ordered
-    )
+    listed = ordered[:_MAX_LISTED_REJECTIONS]
+
+    blocks = [
+        f"{NO_CODING_LEAD}\n"
+        f"No code reached the {_as_whole_percentage(threshold)} confidence "
+        f"threshold, so this record needs human review."
+    ]
+    blocks += [
+        f"{' > '.join(name for _, name in c.path)} — "
+        f"{_as_whole_percentage(c.confidence_aggregate)}\n"
+        f"  {c.decisive_explanation}"
+        for c in listed
+    ]
+
+    remainder = len(ordered) - len(listed)
+    if remainder:
+        noun = "code" if remainder == 1 else "codes"
+        cutoff = _as_whole_percentage(listed[-1].confidence_aggregate)
+        blocks.append(f"{remainder} further {noun} scored below {cutoff}.")
+
+    return "\n\n".join(blocks)
 
 
 @dataclass
@@ -1304,12 +1372,13 @@ class Orchestrator:
         Returns
         -------
         CodingAssignmentResult
-            Per-record leaf codes from ``classify_feedback``. If
-            ``confidence_threshold`` filters out every candidate, the record's
-            ``assigned_codes`` holds a single entry with null
-            ``coding_level_*``/``confidence_*`` fields and an ``explanation``
-            combining every rejected candidate's reasoning, highest-scoring
-            first.
+            Per-record leaf codes from ``classify_feedback``. ``assigned_codes``
+            is never empty: when no code is applied it holds exactly one entry
+            with null ``coding_level_*``/``confidence_*`` fields and an
+            ``explanation`` leading with ``NO CODING APPLIED.`` (#256). That
+            explanation lists the near misses when ``confidence_threshold``
+            filtered every candidate out, and states that nothing was relevant
+            when no code was selected at any level.
 
         Raises
         ------
@@ -1363,15 +1432,24 @@ class Orchestrator:
                 )
                 for c in top
             ]
-        elif rejected:
-            # Every candidate was filtered out by confidence_threshold: surface
-            # every rejected candidate's explanation instead of an
-            # unexplained empty list.
+        elif rejected and request.confidence_threshold is not None:
+            # Every candidate was filtered out by confidence_threshold: list
+            # the near misses instead of an unexplained empty list. Nothing
+            # can be rejected without a threshold, so the second condition
+            # only narrows the type — it never rules a real case out.
             assigned_codes = [
-                AssignedCodeModel(explanation=_combine_rejected_explanations(rejected))
+                AssignedCodeModel(
+                    explanation=_combine_rejected_explanations(
+                        rejected, request.confidence_threshold
+                    )
+                )
             ]
         else:
-            assigned_codes = []
+            # Nothing was picked at any level. Still return an entry so the
+            # caller never has to explain an empty list to a user (#256).
+            assigned_codes = [
+                AssignedCodeModel(explanation=NO_CODING_NOTHING_RELEVANT_EXPLANATION)
+            ]
 
         coded = [
             CodedFeedbackRecordModel(

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -11,6 +11,7 @@ from qfa.domain.errors import (
     FeedbackTooLargeError,
 )
 from qfa.domain.models import FeedbackRecordSummaryModel
+from qfa.services.orchestrator import NO_CODING_EMPTY_CONTENT_EXPLANATION
 
 from .conftest import FAKE_API_KEY, FakeOrchestrator
 
@@ -599,7 +600,12 @@ class TestEmptyFeedbackContent:
 
     @pytest.mark.asyncio
     async def test_assign_codes_empty_content_returns_no_codes(self, client):
-        """Single /assign-codes with blank content returns 200 with no codes."""
+        """Blank content returns 200 with one explained, null-coded entry.
+
+        Before #256 this returned a bare empty list, so EspoCRM marked the
+        record completed with nothing to display. The entry now carries an
+        explanation naming the empty feedback text as the reason.
+        """
         body = {
             "feedback_record": {"id": "doc-1", "content": ""},
             "coding_levels": {
@@ -622,7 +628,12 @@ class TestEmptyFeedbackContent:
         }
         resp = await client.post("/v1/assign-codes", json=body, headers=_auth_header())
         assert resp.status_code == 200
-        assert resp.json()["assigned_codes"] == []
+        assigned = resp.json()["assigned_codes"]
+        assert len(assigned) == 1
+        assert assigned[0]["coding_level_1_id"] is None
+        assert assigned[0]["confidence_aggregate"] is None
+        assert assigned[0]["explanation"] == NO_CODING_EMPTY_CONTENT_EXPLANATION
+        assert assigned[0]["explanation"].startswith("NO CODING APPLIED.\n")
 
     @pytest.mark.asyncio
     async def test_detect_sensitive_empty_content_returns_not_sensitive(self, client):

--- a/tests/services/test_orchestrator.py
+++ b/tests/services/test_orchestrator.py
@@ -29,7 +29,12 @@ from qfa.domain.models import (
 from qfa.domain.ports import AnonymizationPort, LLMPort
 from qfa.domain.sensitivity_types import SensitivityType
 from qfa.services.coding_classifier import JudgeResponse
-from qfa.services.orchestrator import Orchestrator
+from qfa.services.orchestrator import (
+    NO_CODING_NOTHING_RELEVANT_EXPLANATION,
+    Orchestrator,
+    _combine_rejected_explanations,
+    _ScoredCode,
+)
 from qfa.settings import OrchestratorSettings
 
 TENANT_ID = "tenant-42"
@@ -1589,6 +1594,142 @@ def _make_coding_request(
     )
 
 
+def _make_scored_code(names, scores, explanations):
+    """Build a ``_ScoredCode`` from level names, scores and explanations."""
+    return _ScoredCode(
+        path=[(f"id-{name}", name) for name in names],
+        scores=list(scores),
+        explanations=list(explanations),
+    )
+
+
+class TestNoCodingAppliedMessage:
+    """Formatting of the ``NO CODING APPLIED.`` below-threshold explanation."""
+
+    def test_message_matches_the_documented_layout(self):
+        """Pin the whole rendered message against the format agreed in #256.
+
+        Asserting the exact string (rather than a handful of substrings) is
+        what makes this the contract: lead line, threshold sentence, blank
+        line separators, ``name — percentage`` headers, indented decisive
+        explanations and the trailing remainder count.
+        """
+        rejected = [
+            _make_scored_code(
+                ["Shelter", "Repairs", "Roofing"],
+                [0.8, 0.5, 0.04],
+                [
+                    "Housing is mentioned.",
+                    "Repairs are plausible.",
+                    "No mention of roof damage; the feedback concerns rent costs.",
+                ],
+            ),
+            _make_scored_code(["Water"], [0.03], ["No reference to water access."]),
+            _make_scored_code(
+                ["Food Security"], [0.02], ["Concerns housing, not food."]
+            ),
+            *[
+                _make_scored_code([f"Other {i}"], [0.01], [f"Unrelated {i}."])
+                for i in range(5)
+            ],
+        ]
+
+        message = _combine_rejected_explanations(rejected, threshold=0.1)
+
+        assert message == (
+            "NO CODING APPLIED.\n"
+            "No code reached the 10% confidence threshold, so this record "
+            "needs human review.\n"
+            "\n"
+            "Shelter > Repairs > Roofing — 4%\n"
+            "  No mention of roof damage; the feedback concerns rent costs.\n"
+            "\n"
+            "Water — 3%\n"
+            "  No reference to water access.\n"
+            "\n"
+            "Food Security — 2%\n"
+            "  Concerns housing, not food.\n"
+            "\n"
+            "5 further codes scored below 2%."
+        )
+
+    def test_candidates_are_listed_highest_scoring_first(self):
+        """Order by score descending so the closest near-miss is read first.
+
+        The traversal appends rejections in framework order, not score
+        order, so the formatter must sort rather than rely on input order.
+        """
+        rejected = [
+            _make_scored_code(["Low"], [0.01], ["Barely related."]),
+            _make_scored_code(["High"], [0.09], ["Almost made it."]),
+        ]
+
+        message = _combine_rejected_explanations(rejected, threshold=0.1)
+
+        assert message.index("High — 9%") < message.index("Low — 1%")
+
+    def test_remainder_line_is_absent_when_three_or_fewer_rejected(self):
+        """No "further codes" line when the list is already complete.
+
+        A count line reading "0 further codes" would be noise; the absence
+        of the line is what tells the reader nothing was truncated.
+        """
+        rejected = [
+            _make_scored_code([f"Code {i}"], [0.01 * i], [f"Weak {i}."])
+            for i in range(1, 4)
+        ]
+
+        message = _combine_rejected_explanations(rejected, threshold=0.1)
+
+        assert "further code" not in message
+
+    def test_remainder_line_is_singular_for_exactly_one_extra(self):
+        """Use "1 further code", not "1 further codes", in user-facing text."""
+        rejected = [
+            _make_scored_code([f"Code {i}"], [0.09 - i / 100], [f"Weak {i}."])
+            for i in range(4)
+        ]
+
+        message = _combine_rejected_explanations(rejected, threshold=0.1)
+
+        assert message.endswith("1 further code scored below 7%.")
+
+    def test_only_the_decisive_level_explanation_is_shown(self):
+        """Show the level that caused rejection, not one line per level.
+
+        The traversal stops descending at the first sub-threshold level, so
+        the last accumulated level is both the lowest-scoring one and the
+        reason the candidate was dropped. The earlier levels passed and
+        would only add noise.
+        """
+        rejected = [
+            _make_scored_code(
+                ["Shelter", "Roofing"],
+                [0.8, 0.04],
+                ["Housing is mentioned.", "No mention of roof damage."],
+            )
+        ]
+
+        message = _combine_rejected_explanations(rejected, threshold=0.1)
+
+        assert "No mention of roof damage." in message
+        assert "Housing is mentioned." not in message
+
+    def test_confidences_render_as_whole_percentages_not_decimals(self):
+        """Percentages read naturally to non-technical EspoCRM users.
+
+        The pre-#256 format emitted raw ``0.04``-style decimals next to a
+        "Level 2" label, which users had to mentally convert.
+        """
+        rejected = [_make_scored_code(["Water"], [0.04], ["No water mentioned."])]
+
+        message = _combine_rejected_explanations(rejected, threshold=0.15)
+
+        assert "4%" in message
+        assert "15%" in message
+        assert "0.04" not in message
+
+
 class TestAssignCodesConfidenceThreshold:
     @pytest.mark.asyncio
     async def test_all_candidates_rejected_returns_null_codes_with_explanation(
@@ -1632,11 +1773,16 @@ class TestAssignCodesConfidenceThreshold:
         assert "Only loosely related." in code.explanation
 
     @pytest.mark.asyncio
-    async def test_llm_never_picks_anything_returns_plain_empty_list(self, settings):
-        """Confirm a genuine empty pick is not treated as a near-miss.
+    async def test_llm_never_picks_anything_explains_that_nothing_was_relevant(
+        self, settings
+    ):
+        """Confirm a genuine empty pick is explained rather than returned bare.
 
-        A genuine empty pick (no threshold rejection ever happened) still
-        returns a plain empty list, not a null-coded near-miss entry.
+        A genuine empty pick (no threshold rejection ever happened) used to
+        return an empty list, which left EspoCRM with nothing to show while
+        still marking the record completed (#256). It now returns a single
+        null-coded entry whose explanation distinguishes "nothing was
+        relevant" from the near-miss case.
         """
         fake_llm = FakeLLMPort(
             responses=[_make_llm_response(structured='{"selected": []}')]
@@ -1653,7 +1799,12 @@ class TestAssignCodesConfidenceThreshold:
             _make_coding_request(confidence_threshold=0.9), _future_deadline()
         )
 
-        assert result.coded_feedback_records[0].assigned_codes == ()
+        assigned = result.coded_feedback_records[0].assigned_codes
+        assert len(assigned) == 1
+        assert assigned[0].coding_level_1_id is None
+        assert assigned[0].confidence_aggregate is None
+        assert assigned[0].explanation == NO_CODING_NOTHING_RELEVANT_EXPLANATION
+        assert assigned[0].explanation.startswith("NO CODING APPLIED.\n")
 
     @pytest.mark.asyncio
     async def test_all_rejected_explanations_are_combined_highest_first(self, settings):


### PR DESCRIPTION
## What changed

Three code paths in `assign-codes` could end with no code assigned, and only one of them explained itself. The other two returned a bare `assigned_codes: []`, which EspoCRM surfaced as an empty `autoCodingExplanation` on a record still marked `completed` — a successful call that told the user nothing.

`assigned_codes` is now **never empty**. Whenever no code is applied the response is a 200 carrying exactly one entry with null `coding_level_*` / `confidence_*` fields and an `explanation` whose first line is the literal `NO CODING APPLIED.`

| Trigger | Before | After |
|---|---|---|
| Empty `content` (`qfa.api.routes.assign_codes`) | `[]` | entry: *"The feedback text was empty, so there was nothing to code."* |
| All candidates below `confidence_threshold` | one entry, unlabelled decimal dump | reformatted near-miss list (below) |
| Nothing selected at any hierarchy level | `[]` | entry: *"No code in the framework was judged relevant to this feedback."* |

The below-threshold message was also reformatted for a non-technical reader:

- confidences render as whole percentages (`4%`) instead of raw decimals (`0.04`);
- only the **decisive** level's judge reasoning is shown — the traversal stops at the first sub-threshold level, so the last accumulated level is both the lowest-scoring one and the reason the candidate was dropped. Earlier levels passed and were only noise;
- at most **3** near misses are spelled out, highest-scoring first, with any remainder collapsed into a single count line.

The discriminator for clients is `coding_level_1_id is None`, not list length.

## Examples of the explanations produced

**1. Empty feedback text** — short-circuited with no LLM call (issue #138):

```text
NO CODING APPLIED.
The feedback text was empty, so there was nothing to code.
```

**2. Everything filtered out by `confidence_threshold`** — this exact rendering is pinned by `test_message_matches_the_documented_layout` (threshold `0.1`, eight rejected candidates):

```text
NO CODING APPLIED.
No code reached the 10% confidence threshold, so this record needs human review.

Shelter > Repairs > Roofing — 4%
  No mention of roof damage; the feedback concerns rent costs.

Water — 3%
  No reference to water access.

Food Security — 2%
  Concerns housing, not food.

5 further codes scored below 2%.
```

The trailing count line is cut off at the **lowest listed** candidate's score, so "below 2%" refers to `Food Security — 2%`, the third and last one shown.

**3. Nothing judged relevant at any level** — the LLM selected nothing, so no threshold rejection ever happened:

```text
NO CODING APPLIED.
No code in the framework was judged relevant to this feedback.
```

**Formatting variants of case 2**, each with its own test:

- **Three or fewer near misses** → the remainder line is omitted entirely. Its absence is what tells the reader nothing was truncated; a `0 further codes` line would be noise.
- **Exactly one extra** → singular: `1 further code scored below 7%.`
- **Ordering** → candidates are sorted by score descending, because the traversal appends rejections in framework order, not score order. The closest near miss is always read first.

## Files

- `src/qfa/services/orchestrator.py` — public `NO_CODING_LEAD`, `NO_CODING_EMPTY_CONTENT_EXPLANATION`, `NO_CODING_NOTHING_RELEVANT_EXPLANATION` constants; `_as_whole_percentage`; rewritten `_combine_rejected_explanations(rejected, threshold)`; `_ScoredCode.decisive_explanation`; non-empty `else` branch
- `src/qfa/api/routes.py` — empty-content short-circuit returns an explained entry; route docstring rewritten (drives OpenAPI)
- `src/qfa/api/schemas.py` — `ApiAssignedCode.explanation` description updated
- `tests/services/test_orchestrator.py`, `tests/api/test_routes.py` — 6 new formatter tests + 2 rewritten behaviour tests
- `docs/rest-api/index.md`, `docs/integrations/espo-crm.md` — contract + rendered example
- `.gitignore` — ignore `graphify-out/` build artifacts

## Design notes

- **No `assert` for the threshold narrowing.** A rejection cannot happen without a threshold, which invites `assert threshold is not None`. There is no precedent for `assert` in `src/qfa/` (asserts vanish under `python -O`), so the check is folded into the branch condition — `elif rejected and request.confidence_threshold is not None:` — which satisfies `ty` and degrades to the "nothing relevant" message in the impossible case. No branch is unreachable.
- **The exact-string test is the contract.** Asserting the whole rendered block rather than a few `in` substring checks is what actually pins the blank-line separators, the two-space indentation and the em-dash headers. Substring assertions would pass on a subtly reordered message.
- **Constant placement is driven by `import-linter`.** Cases 1–3 straddle `qfa.api` and `qfa.services`. Publishing the strings from `qfa.services.orchestrator` and importing them into the route keeps one source of truth while flowing with the allowed dependency direction; defining them in the route would force `qfa.services` → `qfa.api`, which the "Enforce hexagonal layers" contract rejects.

## Verification

`make test` 559 passed · `make lint` clean, all 3 `import-linter` contracts kept · `make docs` build succeeded.

## Impact & risk

- **Behavioural change for any client that treats `assigned_codes == []` as "no code".** The list is now never empty; the discriminator is `coding_level_1_id is None`. The known consumer, `scripts/espo_crm/feedback_trigger/4_1_assign_codes.php`, already reads `assigned_codes.0.*` and assigns nulls to the coding-level fields, so it needs **no change** — it simply starts populating `autoCodingExplanation` in the two cases that previously sent nothing. Espo already sends `confidence_threshold: 0.1`, matching the example above.
- Case 1 still short-circuits with **no LLM call**, so there is no cost change. Cases 2 and 3 are pure formatting of data already computed.
- Explanations are **English only** regardless of the feedback language — `ApiAssignCodesRequest` has no `output_language` field, and localization was out of scope for the spec.
- Fully revertible with `git revert`; no schema, auth, or migration changes.

Fixes #256
