### PR TITLE
chore: gitignore the agent loop's tasks/ scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,8 @@ config
 /.envrc
 graphify-out/
 
+# Agent scratch: the agentic-engineering-loop's build stage writes its plan and
+# working notes to tasks/ and expects the repo to ignore them. Left tracked,
+# they leak into PRs and can fail the loop's own clean-tree gate.
+tasks/
+


### PR DESCRIPTION
Adds `tasks/` to `.gitignore`.

## Why

The [agentic-engineering-loop](https://github.com/XomniaAI/agentic-engineering-loop) build stage writes the agent's plan and working notes to `tasks/`, and its `BUILD_PROMPT` tells the agent, verbatim, that the directory *"is gitignored, so writing to it cannot dirty `git status`"*. That is not true in this repo.

The loop then applies a **hard** gate after every build: if `git status --porcelain --untracked-files=all` is non-empty, the build is declared incomplete, nothing is pushed, no PR is opened, and the ticket is escalated to a human. Today that gate discarded a complete, green build on #258 (586 tests passing, `make lint` clean) over untracked scratch. `graphify-out/` was already fixed for the same reason in 263f742; `tasks/` is the remaining gap.

The loop currently only survives this because it defensively filters `tasks/` itself before applying the gate — a defense that exists precisely because repos forget this entry. Adding it here makes the prompt's claim true and stops `tasks/` leaking into PRs.

## Scope

One line plus a comment. No code, no behaviour change.

Loop-side fixes so this class of failure cannot recur regardless of a repo's `.gitignore` are tracked separately in the loop's own repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)