### PR TITLE
refactor(services): extract LLMCallExecutor collaborator from Orchestrator

### DIFF
--- a/docs/architecture/03-components.md
+++ b/docs/architecture/03-components.md
@@ -111,12 +111,29 @@ the rationale, and flow/sequence diagrams.
 
 Each method is pure use-case logic — no scope or correlation plumbing. `call_scope` is entered by a FastAPI dependency declared on the route (`Depends(call_scope_for(Operation.X))`), so by the time an orchestrator method runs `current_call_context` is already set. See [Cross-cutting concerns](04-crosscutting.md) for the full picture.
 
+### The LLM-call executor
+
+The scaffolding every use case wraps its LLM calls in lives on one collaborator, {py:class}`~qfa.services.llm_call_executor.LLMCallExecutor`, which the orchestrator holds as `self._executor` and delegates to:
+
+| Method | Concern |
+|---|---|
+| `check_deadline_and_get_timeout(deadline)` | Derive the per-call timeout from the remaining request budget; raise {py:exc}`~qfa.domain.errors.AnalysisTimeoutError` when too little time is left |
+| `check_token_limit(system_message, user_message)` | Pre-flight token estimate; raise {py:exc}`~qfa.domain.errors.FeedbackTooLargeError` when over `LLM_MAX_TOTAL_TOKENS` |
+| `anonymize_records(records, anonymize)` | Redact each record's text, returning new records plus the merged restore mapping |
+| `bounded_complete(semaphore, …)` | One completion bounded by both a concurrency semaphore and the deadline; used by the hierarchical map/judge/reduce phases |
+
+It is a **plain concrete class** — not a Protocol, not a base class, and not declared in `qfa.domain.ports`. It wraps no external system, so it is not a port; and behaviour reuse in this codebase is always composition, so nothing inherits from it. Both points are decided in [ADR-017: Decompose the Orchestrator by composition only](../adr/017-orchestrator-composition-only.md), which is also why the composition root injects the executor rather than letting the service construct its own.
+
+The executor is built over the **primary** LLM connection. Judge calls that must run on the second connection pass it per call (`bounded_complete(..., llm=self._judge_llm)`); omitting the argument uses the primary.
+
+Tests construct the real executor over the existing `FakeLLMPort` / `FakeAnonymizer` doubles (`tests/services/test_llm_call_executor.py`) — there is no fake executor to keep in sync.
+
 ## Composition root
 
 `qfa.api.app.create_app()` builds the FastAPI instance; the `lifespan` context manager wires the dependency graph at startup. The wiring splits into two halves:
 
 - **Infrastructure half** (in `qfa.api.app`): load settings, build the base LLM client — plus a second one for judge calls when `JUDGE_LLM_MODEL` is set — create the async DB engine, wrap each LLM in {py:class}`~qfa.adapters.tracking_llm.TrackingLLMAdapter` for usage tracking, set up the auth adapter, build the embedder (logging its construction so operators see it on startup).
-- **Domain half** (in {py:func}`qfa.api.composition.build_orchestrator`): given settings plus the already-wrapped LLM and embedder, construct the {py:class}`~qfa.adapters.presidio_anonymizer.PresidioAnonymizer`, register custom model prices with LiteLLM, and assemble the {py:class}`~qfa.services.orchestrator.Orchestrator`.
+- **Domain half** (in {py:func}`qfa.api.composition.build_orchestrator`): given settings plus the already-wrapped LLM and embedder, construct the {py:class}`~qfa.adapters.presidio_anonymizer.PresidioAnonymizer` and the {py:class}`~qfa.services.llm_call_executor.LLMCallExecutor`, register custom model prices with LiteLLM, and assemble the {py:class}`~qfa.services.orchestrator.Orchestrator`.
 
 The lifespan then attaches the orchestrator, API keys, and the usage repository to `app.state` for the request lifecycle to read.
 

--- a/docs/architecture/04-crosscutting.md
+++ b/docs/architecture/04-crosscutting.md
@@ -26,6 +26,7 @@ sequenceDiagram
 Notes:
 
 - The mapping lives in memory for the request and is discarded when the orchestrator method returns.
+- Batch redaction (one call per record, mappings merged) goes through {py:meth}`~qfa.services.llm_call_executor.LLMCallExecutor.anonymize_records` rather than being open-coded per use case; single-message redaction calls the {py:class}`~qfa.domain.ports.AnonymizationPort` directly.
 - The de-anonymise step runs over the serialised response — substitutions are textual, so the round-trip is a string replacement, not a structured walk.
 
 ## Call context and usage tracking
@@ -73,7 +74,7 @@ Both adapters depend on `qfa.services.call_context`; neither depends on the othe
 | Layer | Concern | Mechanism |
 |---|---|---|
 | Route handler | Per-request deadline | `deadline = now(UTC) + 240s`, passed as an absolute `datetime` into the orchestrator |
-| Orchestrator | Deadline check | Before each LLM call: if remaining time is negative, raise {py:exc}`~qfa.domain.errors.AnalysisTimeoutError` |
+| Application service ({py:class}`~qfa.services.llm_call_executor.LLMCallExecutor`) | Deadline check | Before each LLM call: if remaining time is negative, raise {py:exc}`~qfa.domain.errors.AnalysisTimeoutError`. The check and the timeout it derives live on the shared executor the orchestrator delegates to, so no use case re-implements the arithmetic |
 | Adapter ({py:class}`~qfa.adapters.llm_client.LiteLLMClient`) | Retry on transient errors | `tenacity.retry` with exponential backoff (1s→10s, 120s budget) for {py:exc}`~qfa.domain.errors.LLMTimeoutError` and {py:exc}`~qfa.domain.errors.LLMRateLimitError` |
 | Adapter ({py:class}`~qfa.adapters.llm_client.LiteLLMClient`) | Per-call timeout | Passed through to `litellm.acompletion(timeout=…)` |
 | Adapter ({py:class}`~qfa.adapters.llm_client.LiteLLMClient`) | Token budget guard | Estimates `len(text) / chars_per_token`; raises {py:exc}`~qfa.domain.errors.FeedbackTooLargeError` if over `LLM_MAX_TOTAL_TOKENS` |

--- a/docs/development/implementing-a-new-endpoint.md
+++ b/docs/development/implementing-a-new-endpoint.md
@@ -119,7 +119,7 @@ async def classify(
     deadline: datetime,
 ) -> ClassificationResultModel:
     """Assign one label to a feedback record via a single LLM call."""
-    timeout = self._check_deadline_and_get_timeout(deadline)
+    timeout = self._executor.check_deadline_and_get_timeout(deadline)
     user_message = build_feedback_record_envelope(
         request.feedback_record, include_metadata=False
     )
@@ -151,6 +151,18 @@ most endpoints need none. The anonymisation round-trip and the
 deadline/timeout/retry policy are documented under
 [cross-cutting concerns](../architecture/04-crosscutting.md) — match them
 rather than reinventing them.
+
+The scaffolding those concerns need is not written per use case. `self._executor`
+is a {py:class}`~qfa.services.llm_call_executor.LLMCallExecutor` — an injected
+collaborator (never a base class, see
+[ADR-017](../adr/017-orchestrator-composition-only.md)) that owns four shared
+behaviours: `check_deadline_and_get_timeout` (step 1 above),
+`anonymize_records` (step 2 for a whole batch), `check_token_limit` (the
+pre-flight budget guard, used by the multi-call coding path), and
+`bounded_complete` (a semaphore-bounded completion for concurrent pipelines).
+Call them; do not re-derive the deadline arithmetic or the token estimate in a
+new method. Anything a use case needs that is genuinely shared belongs on the
+executor too — or in a further collaborator, never in a shared base class.
 
 ## 4. Add the API schemas
 

--- a/spec/issue-262.md
+++ b/spec/issue-262.md
@@ -1,0 +1,57 @@
+Part of the `Orchestrator` decomposition epic (#112). This is the shared foundation every
+service extraction builds on, so it lands second (right after the ADR) and changes no
+public behaviour.
+
+Depends-on: #261
+
+## Spec
+
+**What:** Extract the LLM-call scaffolding currently spread across `Orchestrator`'s
+private methods into a new plain class `LLMCallExecutor` in
+`src/qfa/services/llm_call_executor.py`. `Orchestrator` keeps all six public methods with
+identical signatures and delegates the extracted work to an injected executor.
+
+Methods that move:
+
+| Method | Current line | Role |
+|---|---|---|
+| `_anonymize_records` | ~839 | PII redaction before the LLM call |
+| `_bounded_complete` | ~860 | the retrying, deadline-bounded LLM call |
+| `_check_deadline_and_get_timeout` | ~1435 | per-call timeout derivation |
+| `_check_token_limit` | ~1600 | pre-flight token budget guard |
+
+**Why:** Every use-case service needs this same scaffolding. Deciding *how* it is shared
+is the whole architectural question this epic answers, and #112 settled it: a single
+injected collaborator, not a base class. Landing the collaborator on its own — while
+`Orchestrator` is still intact and its full test suite still green — proves the seam is
+correct before four extractions commit to it. If the executor's boundary is wrong, this
+is the cheapest possible place to discover it.
+
+No route, DI, or response change happens here.
+
+## Acceptance criteria
+
+- [ ] `src/qfa/services/llm_call_executor.py` defines `class LLMCallExecutor:` with
+      **no base class** and no `Protocol`.
+- [ ] `LLMCallExecutor` is **not** referenced from `qfa/domain/ports.py`.
+- [ ] Its constructor takes the driven ports and config it needs — `llm: LLMPort`,
+      `anonymizer: AnonymizationPort`, `settings: OrchestratorSettings`,
+      `llm_timeout_seconds: float`, `max_total_tokens: int`.
+- [ ] The four methods above are moved onto it (renamed to public names where they are
+      now cross-class calls) and **deleted** from `Orchestrator`.
+- [ ] `Orchestrator` holds an `LLMCallExecutor` and delegates; all six public methods
+      (`analyze_bulk`, `analyze_hierarchical`, `summarize_bulk`, `summarize`,
+      `assign_codes`, `detect_sensitive_content`) keep byte-identical signatures.
+- [ ] `build_orchestrator` in `src/qfa/api/composition.py` constructs the executor and
+      passes it in; `build_orchestrator`'s own signature is unchanged.
+- [ ] New `tests/services/test_llm_call_executor.py` covers the executor directly:
+      retry-on-transient, non-transient passthrough, deadline expiry, token-limit
+      rejection, and anonymize→deanonymize round-tripping — constructed over the existing
+      `FakeLLMPort` / `FakeAnonymizer`, not over a new fake executor.
+- [ ] `tests/services/test_orchestrator.py` and
+      `tests/services/test_orchestrator_hierarchical.py` still pass with changes limited
+      to how the `Orchestrator` under test is constructed. No test assertion is weakened
+      or deleted to accommodate the refactor.
+- [ ] `make test` and `make lint` pass, including all three `import-linter` contracts.
+- [ ] Behaviour-preserving: no HTTP request/response shape, status code, or error payload
+      changes.

--- a/src/qfa/api/composition.py
+++ b/src/qfa/api/composition.py
@@ -25,6 +25,12 @@ via the ``llm`` keyword argument. Callers that don't (scripts,
 notebooks, ad-hoc evaluation harnesses) call ``build_orchestrator``
 with no overrides and get an Orchestrator over a plain LiteLLM client.
 
+Besides the driven adapters, this module also builds the
+:class:`~qfa.services.llm_call_executor.LLMCallExecutor` the orchestrator
+delegates its LLM-call scaffolding to. Per ADR-017 that collaborator is
+*injected*, not self-constructed, so the composition root stays the one
+place where the object graph is assembled.
+
 The orchestrator may hold *two* LLM connections: the primary one used for
 generation, and an optional second one used only for judge calls, configured
 via ``JUDGE_LLM_*``. :func:`resolve_judge_llm_settings` applies the
@@ -42,6 +48,7 @@ import yaml
 from qfa.adapters.embedding import build_onnx_embedder
 from qfa.adapters.presidio_anonymizer import PresidioAnonymizer
 from qfa.domain.ports import EmbeddingPort, LLMPort
+from qfa.services.llm_call_executor import LLMCallExecutor
 from qfa.services.orchestrator import Orchestrator
 from qfa.settings import AppSettings, EmbeddingSettings, JudgeLLMSettings, LLMSettings
 
@@ -235,13 +242,28 @@ def build_orchestrator(
     if embedder is None:
         embedder = build_embedder(settings.embedding)
 
+    anonymizer = PresidioAnonymizer()
+    # The shared LLM-call scaffolding is an injected collaborator, not a base
+    # class (ADR-017), so the composition root builds it here and hands it to
+    # the service rather than letting the service construct its own. It is
+    # built over the *primary* LLM connection; judge calls override the client
+    # per call.
+    executor = LLMCallExecutor(
+        llm=llm,
+        anonymizer=anonymizer,
+        settings=settings.orchestrator,
+        llm_timeout_seconds=settings.llm.timeout_seconds,
+        max_total_tokens=settings.llm.max_total_tokens,
+    )
+
     return Orchestrator(
         llm=llm,
         judge_llm=judge_llm,
-        anonymizer=PresidioAnonymizer(),
+        anonymizer=anonymizer,
         settings=settings.orchestrator,
         analyze_settings=settings.analyze,
         llm_timeout_seconds=settings.llm.timeout_seconds,
         max_total_tokens=settings.llm.max_total_tokens,
         embedder=embedder,
+        executor=executor,
     )

--- a/src/qfa/services/llm_call_executor.py
+++ b/src/qfa/services/llm_call_executor.py
@@ -1,0 +1,216 @@
+"""Shared LLM-call scaffolding for the application services.
+
+Every use case in :mod:`qfa.services` wraps its LLM calls in the same
+four concerns: redact PII before the call, derive a per-call timeout from
+the request deadline, guard the token budget, and bound concurrent calls
+with a semaphore. :class:`LLMCallExecutor` owns those four and nothing
+else, so a use-case service can be read without them.
+
+Per ADR-017 this is a plain concrete class, deliberately **not** a
+Protocol and **not** a base class:
+
+- It is not a driven port. Ports in this codebase invert dependencies on
+  *infrastructure*; this object wraps no external system, it orchestrates
+  calls to an :class:`~qfa.domain.ports.LLMPort` that already exists. It
+  is therefore not declared in :mod:`qfa.domain.ports`.
+- Services receive it as a constructor dependency and delegate to it.
+  Nothing inherits from it — behaviour reuse in this codebase is always
+  composition, and ``class X(Y):`` stays readable as "X implements port
+  Y".
+
+Tests construct the *real* executor over the existing ``FakeLLMPort`` /
+``FakeAnonymizer`` doubles; there is no fake executor.
+"""
+
+import asyncio
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from qfa.domain.errors import AnalysisTimeoutError, FeedbackTooLargeError
+from qfa.domain.models import FeedbackRecordModel, LLMResponse, T_Response
+from qfa.domain.ports import AnonymizationPort, LLMPort
+from qfa.settings import LLM_RETRY_BUDGET_MULTIPLIER, OrchestratorSettings
+
+#: Minimum time (seconds) required for an LLM attempt to be viable.
+_MINIMUM_ATTEMPT_WINDOW = 10.0
+
+
+@dataclass
+class SlotTiming:
+    """Split timing for one semaphore-bounded hierarchical LLM call.
+
+    ``queued_seconds`` is the time spent waiting to acquire the concurrency
+    semaphore; ``call_seconds`` is the LLM completion itself, measured only
+    *after* the slot was acquired. Keeping them apart makes the per-chunk
+    debug lines honest: a single combined duration folds queue-wait into
+    "call time", so a 5s call that waited 100s in the queue looked like a
+    110s call (and like a near-timeout when it was nothing of the sort).
+    """
+
+    queued_seconds: float = 0.0
+    call_seconds: float = 0.0
+
+
+class LLMCallExecutor:
+    """Deadline-, budget- and concurrency-aware wrapper around an LLM port.
+
+    Parameters
+    ----------
+    llm : LLMPort
+        The LLM provider adapter every call runs on by default. Call sites
+        that must use a *different* connection — the LLM-as-judge calls,
+        which may be configured onto their own model — pass it explicitly
+        to :meth:`bounded_complete`.
+    anonymizer : AnonymizationPort
+        The anonymisation adapter used to redact PII before LLM calls.
+    settings : OrchestratorSettings
+        Cross-cutting configuration; this object reads ``chars_per_token``
+        for its token estimate.
+    llm_timeout_seconds : float
+        Maximum time in seconds for a single LLM call, before the deadline
+        is taken into account.
+    max_total_tokens : int
+        Maximum estimated total tokens for a single request.
+    """
+
+    def __init__(
+        self,
+        llm: LLMPort,
+        anonymizer: AnonymizationPort,
+        settings: OrchestratorSettings,
+        llm_timeout_seconds: float,
+        max_total_tokens: int,
+    ) -> None:
+        self._llm = llm
+        self._anonymizer: AnonymizationPort = anonymizer
+        self._settings = settings
+        self._llm_timeout_seconds = llm_timeout_seconds
+        self._max_total_tokens = max_total_tokens
+
+    def anonymize_records(
+        self,
+        records: tuple[FeedbackRecordModel, ...],
+        anonymize: bool,
+    ) -> tuple[tuple[FeedbackRecordModel, ...], dict[str, str]]:
+        """Anonymise each record's text, returning new records + merged mapping.
+
+        Metadata is left untouched (codes/dates are not PII and feed the
+        deterministic trend table). When ``anonymize`` is False, records are
+        returned unchanged with an empty mapping.
+        """
+        if not anonymize:
+            return records, {}
+        merged: dict[str, str] = {}
+        new_records: list[FeedbackRecordModel] = []
+        for record in records:
+            redacted, mapping = self._anonymizer.anonymize(record.content)
+            merged.update(mapping)
+            new_records.append(record.model_copy(update={"content": redacted}))
+        return tuple(new_records), merged
+
+    async def bounded_complete(
+        self,
+        semaphore: asyncio.Semaphore,
+        *,
+        llm: LLMPort | None = None,
+        system_message: str,
+        user_message: str,
+        tenant_id: str,
+        response_model: type[T_Response],
+        deadline: datetime,
+        timing: SlotTiming | None = None,
+    ) -> LLMResponse[T_Response]:
+        """Run one LLM completion, bounded by ``semaphore`` and the deadline.
+
+        ``semaphore`` caps how many completions run at once across the whole
+        hierarchical pipeline (map, leaf judge, reduce), so concurrency stays
+        within ``max_concurrent_chunks`` across every phase. The
+        deadline/timeout is computed *after* acquiring a slot, so a
+        completion that queued behind others still honours the remaining budget
+        (and raises ``AnalysisTimeoutError`` if the deadline passed while it
+        waited).
+
+        ``llm`` overrides the connection for this one call. It exists because
+        this helper serves both map/reduce and the leaf judges, which may run
+        on different connections (see ``judge_llm``); ``None`` uses the
+        executor's own client. Every current call site passes it explicitly so
+        the connection each call uses is visible where the call is written.
+        Note the semaphore is shared regardless: the bound is on total
+        in-flight calls, not per connection.
+
+        When ``timing`` is supplied it is populated with the queue-wait and the
+        post-acquire call duration as two separate fields, so callers can log
+        them apart rather than reporting one combined number that hides how long
+        the call sat waiting for a slot.
+        """
+        client = llm if llm is not None else self._llm
+        queue_start = time.perf_counter()
+        async with semaphore:
+            acquired_at = time.perf_counter()
+            if timing is not None:
+                timing.queued_seconds = acquired_at - queue_start
+            # Compute the timeout only now: queue-wait already elapsed, so the
+            # per-call window reflects the budget that actually remains.
+            timeout = self.check_deadline_and_get_timeout(deadline)
+            try:
+                return await client.complete(
+                    system_message=system_message,
+                    user_message=user_message,
+                    tenant_id=tenant_id,
+                    response_model=response_model,
+                    timeout=timeout,
+                )
+            finally:
+                if timing is not None:
+                    timing.call_seconds = time.perf_counter() - acquired_at
+
+    def check_deadline_and_get_timeout(self, deadline: datetime) -> float:
+        """Raise if the deadline has passed or too little time remains.
+
+        Return a timeout (seconds) bounded by the deadline and the
+        configured per-call limit.
+        """
+        remaining = (deadline - datetime.now(UTC)).total_seconds()
+        if remaining <= 0:
+            raise AnalysisTimeoutError("Deadline exceeded")
+        if remaining < _MINIMUM_ATTEMPT_WINDOW:
+            raise AnalysisTimeoutError(
+                f"Insufficient time remaining ({remaining:.1f}s) for an LLM attempt"
+            )
+        # A single ``LLMPort.complete`` may retry internally, spending up to
+        # ``LLM_RETRY_BUDGET_MULTIPLIER`` times this per-attempt timeout in worst
+        # case (see ``qfa.adapters.llm_client``). Divide the remaining deadline
+        # by the same factor so even a fully-retried last call finishes before
+        # the deadline. With a generous deadline the per-call cap binds first, so
+        # this only bites as the deadline approaches.
+        per_attempt_budget = remaining / LLM_RETRY_BUDGET_MULTIPLIER
+        return min(self._llm_timeout_seconds, per_attempt_budget)
+
+    def check_token_limit(self, system_message: str, user_message: str) -> None:
+        """Estimate total tokens and raise if over the limit.
+
+        Parameters
+        ----------
+        system_message : str
+            The assembled system message.
+        user_message : str
+            The assembled user message containing the feedback records.
+
+        Raises
+        ------
+        FeedbackTooLargeError
+            When estimated tokens exceed the configured limit.
+        """
+        assembled_text = system_message + user_message
+        estimated_tokens = len(assembled_text) // self._settings.chars_per_token
+        if estimated_tokens > self._max_total_tokens:
+            msg = (
+                f"Estimated tokens ({estimated_tokens}) exceed limit "
+                f"({self._max_total_tokens})"
+            )
+            raise FeedbackTooLargeError(
+                msg,
+                estimated_tokens=estimated_tokens,
+                limit=self._max_total_tokens,
+            )

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -2,13 +2,18 @@
 
 Assembles prompts, enforces token limits, filters prompt injection,
 manages retries with exponential backoff, and enforces deadlines.
+
+The scaffolding those last three share across use cases — anonymise a batch
+of records, derive a per-call timeout from the deadline, guard the token
+budget, run a semaphore-bounded completion — lives on the injected
+:class:`~qfa.services.llm_call_executor.LLMCallExecutor` rather than on this
+class (ADR-017).
 """
 
 import asyncio
 import json
 import logging
 import re
-import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import ClassVar, Optional, TypeVar
@@ -20,7 +25,6 @@ from qfa.domain.clustering_models import CodingTrendTable
 from qfa.domain.errors import (
     AnalysisError,
     AnalysisTimeoutError,
-    FeedbackTooLargeError,
     LLMError,
     LLMRateLimitError,
     LLMTimeoutError,
@@ -36,14 +40,12 @@ from qfa.domain.models import (
     CodingNode,
     FeedbackRecordModel,
     FeedbackRecordSummaryModel,
-    LLMResponse,
     SensitivityAnalysisRequestModel,
     SensitivityAnalysisResultModel,
     SensitivityAnalysisResultModelList,
     SingleSummaryRequestModel,
     SummaryRequestModel,
     SummaryResultModel,
-    T_Response,
 )
 from qfa.domain.ports import AnonymizationPort, EmbeddingPort, LLMPort
 from qfa.domain.sensitivity_types import SENSITIVITY_TYPE_DESCRIPTIONS
@@ -60,6 +62,7 @@ from qfa.services.hierarchical_prompts import (
     build_reduce_system_message,
     build_reduce_user_message,
 )
+from qfa.services.llm_call_executor import LLMCallExecutor, SlotTiming
 from qfa.services.prompts import (
     ANALYZE_ACTION_PROMPT,
     ANALYZE_GUARDRAILS_PROMPT,
@@ -72,7 +75,6 @@ from qfa.services.prompts import (
     build_output_language_instruction,
 )
 from qfa.settings import (
-    LLM_RETRY_BUDGET_MULTIPLIER,
     AnalyzeSettings,
     OrchestratorSettings,
 )
@@ -163,9 +165,6 @@ Output rules:
 - No extra text
 - Example output: 0.82
 """
-
-#: Minimum time (seconds) required for an LLM attempt to be viable.
-_MINIMUM_ATTEMPT_WINDOW = 10.0
 
 _JUDGE_USER_MESSAGE = "."
 
@@ -342,28 +341,17 @@ def _combine_rejected_explanations(
     return "\n\n".join(blocks)
 
 
-@dataclass
-class _SlotTiming:
-    """Split timing for one semaphore-bounded hierarchical LLM call.
-
-    ``queued_seconds`` is the time spent waiting to acquire the concurrency
-    semaphore; ``call_seconds`` is the LLM completion itself, measured only
-    *after* the slot was acquired. Keeping them apart makes the per-chunk
-    debug lines honest: a single combined duration folds queue-wait into
-    "call time", so a 5s call that waited 100s in the queue looked like a
-    110s call (and like a near-timeout when it was nothing of the sort).
-    """
-
-    queued_seconds: float = 0.0
-    call_seconds: float = 0.0
-
-
 class Orchestrator:
     """Core orchestration service for feedback analysis.
 
     Assembles prompts from feedback records, validates input,
     calls the LLM through the ``LLMPort``, and manages retries
     with exponential backoff and deadline enforcement.
+
+    Deadline arithmetic, the token-budget guard, batch anonymisation and
+    semaphore-bounded completions are delegated to the injected
+    :class:`~qfa.services.llm_call_executor.LLMCallExecutor` (``executor``
+    below), so this class holds use-case logic rather than call scaffolding.
 
     Parameters
     ----------
@@ -399,6 +387,16 @@ class Orchestrator:
         judges, and the judges in ``summarize_aggregate`` and ``summarize``.
         The per-level judge inside ``assign_codes`` deliberately stays on
         ``llm``.
+    executor : LLMCallExecutor | None
+        The shared LLM-call scaffolding (anonymise-records, deadline→timeout
+        derivation, token-budget guard, semaphore-bounded completion) this
+        orchestrator delegates to, per ADR-017. The composition root
+        (:func:`qfa.api.composition.build_orchestrator`) constructs it
+        explicitly. ``None`` (the default) builds one over the same ``llm``,
+        ``anonymizer``, ``settings``, ``llm_timeout_seconds`` and
+        ``max_total_tokens`` this constructor already received, so callers
+        that don't care about the collaborator — scripts, notebooks, and the
+        bulk of the test suite — need not thread it through.
     """
 
     # Entity types whose placeholders are NOT restored in `analyze` output.
@@ -422,6 +420,7 @@ class Orchestrator:
         analyze_settings: AnalyzeSettings | None = None,
         embedder: EmbeddingPort | None = None,
         judge_llm: LLMPort | None = None,
+        executor: LLMCallExecutor | None = None,
     ) -> None:
         self._llm = llm
         # Judge calls run on their own connection when one is configured, so
@@ -440,6 +439,18 @@ class Orchestrator:
         self._analyze_settings = analyze_settings or AnalyzeSettings()
         self._llm_timeout_seconds = llm_timeout_seconds
         self._max_total_tokens = max_total_tokens
+        # Shared LLM-call scaffolding (ADR-017): an injected collaborator, not a
+        # base class. Default-constructed from the arguments above so the
+        # composition root can inject one without every other construction site
+        # having to. Either way it is built over the *primary* llm; judge calls
+        # pass ``llm=self._judge_llm`` per call.
+        self._executor = executor or LLMCallExecutor(
+            llm=llm,
+            anonymizer=anonymizer,
+            settings=settings,
+            llm_timeout_seconds=llm_timeout_seconds,
+            max_total_tokens=max_total_tokens,
+        )
 
     @classmethod
     def _is_retained_analyze_placeholder(cls, placeholder: str) -> bool:
@@ -500,7 +511,7 @@ class Orchestrator:
             )
             anonymized_prompt, _ = self._anonymizer.anonymize(request.prompt)
 
-        analyse_timeout = self._check_deadline_and_get_timeout(deadline)
+        analyse_timeout = self._executor.check_deadline_and_get_timeout(deadline)
         analyse_response = await self._llm.complete(
             system_message=system_message,
             user_message=anonymized_user_message,
@@ -527,7 +538,7 @@ class Orchestrator:
         quality_score: float | None
         uncertainty_explanation: str
         try:
-            judge_timeout = self._check_deadline_and_get_timeout(deadline)
+            judge_timeout = self._executor.check_deadline_and_get_timeout(deadline)
             judge_system = build_analyze_judge_system_message(
                 source_text=anonymized_user_message,
                 analyst_prompt=anonymized_prompt,
@@ -623,7 +634,7 @@ class Orchestrator:
             "Starting anonymization of %d records...", len(request.feedback_records)
         )
         with timed() as anonymize_sw:
-            anonymized_records, mapping = self._anonymize_records(
+            anonymized_records, mapping = self._executor.anonymize_records(
                 request.feedback_records, anonymize
             )
             anonymized_prompt = request.prompt
@@ -704,7 +715,7 @@ class Orchestrator:
                 len(chunks),
                 len(chunk.records),
             )
-            timing = _SlotTiming()
+            timing = SlotTiming()
             with timed() as chunk_sw:
                 partial = await self._map_chunk(
                     anonymized_prompt,
@@ -772,7 +783,7 @@ class Orchestrator:
                 index: int, chunk: Chunk, partial: Optional[str]
             ) -> float | None:
                 logger.debug("starting judge chunk %d/%d", index, len(chunks))
-                timing = _SlotTiming()
+                timing = SlotTiming()
                 with timed() as judge_sw:
                     score = await self._judge_chunk(
                         anonymized_prompt,
@@ -924,80 +935,6 @@ class Orchestrator:
             coding_trends=trend_table,
         )
 
-    def _anonymize_records(
-        self,
-        records: tuple[FeedbackRecordModel, ...],
-        anonymize: bool,
-    ) -> tuple[tuple[FeedbackRecordModel, ...], dict[str, str]]:
-        """Anonymise each record's text, returning new records + merged mapping.
-
-        Metadata is left untouched (codes/dates are not PII and feed the
-        deterministic trend table). When ``anonymize`` is False, records are
-        returned unchanged with an empty mapping.
-        """
-        if not anonymize:
-            return records, {}
-        merged: dict[str, str] = {}
-        new_records: list[FeedbackRecordModel] = []
-        for record in records:
-            redacted, mapping = self._anonymizer.anonymize(record.content)
-            merged.update(mapping)
-            new_records.append(record.model_copy(update={"content": redacted}))
-        return tuple(new_records), merged
-
-    async def _bounded_complete(
-        self,
-        semaphore: asyncio.Semaphore,
-        *,
-        llm: LLMPort,
-        system_message: str,
-        user_message: str,
-        tenant_id: str,
-        response_model: type[T_Response],
-        deadline: datetime,
-        timing: _SlotTiming | None = None,
-    ) -> LLMResponse[T_Response]:
-        """Run one LLM completion on ``llm``, bounded by ``semaphore`` and the deadline.
-
-        ``semaphore`` caps how many completions run at once across the whole
-        hierarchical pipeline (map, leaf judge, reduce), so concurrency stays
-        within ``max_concurrent_chunks`` across every phase. The
-        deadline/timeout is computed *after* acquiring a slot, so a
-        completion that queued behind others still honours the remaining budget
-        (and raises ``AnalysisTimeoutError`` if the deadline passed while it
-        waited).
-
-        ``llm`` is explicit rather than always ``self._llm`` because this helper
-        serves both map/reduce and the leaf judges, which may run on different
-        connections (see ``judge_llm``). It stays a required argument so each
-        call site states which client it uses. Note the semaphore is shared
-        regardless: the bound is on total in-flight calls, not per connection.
-
-        When ``timing`` is supplied it is populated with the queue-wait and the
-        post-acquire call duration as two separate fields, so callers can log
-        them apart rather than reporting one combined number that hides how long
-        the call sat waiting for a slot.
-        """
-        queue_start = time.perf_counter()
-        async with semaphore:
-            acquired_at = time.perf_counter()
-            if timing is not None:
-                timing.queued_seconds = acquired_at - queue_start
-            # Compute the timeout only now: queue-wait already elapsed, so the
-            # per-call window reflects the budget that actually remains.
-            timeout = self._check_deadline_and_get_timeout(deadline)
-            try:
-                return await llm.complete(
-                    system_message=system_message,
-                    user_message=user_message,
-                    tenant_id=tenant_id,
-                    response_model=response_model,
-                    timeout=timeout,
-                )
-            finally:
-                if timing is not None:
-                    timing.call_seconds = time.perf_counter() - acquired_at
-
     async def _map_chunk(
         self,
         analyst_prompt: str,
@@ -1005,7 +942,7 @@ class Orchestrator:
         tenant_id: str,
         deadline: datetime,
         semaphore: asyncio.Semaphore,
-        timing: _SlotTiming | None = None,
+        timing: SlotTiming | None = None,
         output_language: str | None = None,
     ) -> str:
         """Produce one partial analysis for a chunk (no judging).
@@ -1015,7 +952,7 @@ class Orchestrator:
         partials, and deferring the judges keeps a time-starved judge phase
         from discarding the already-produced synthesis.
         """
-        response = await self._bounded_complete(
+        response = await self._executor.bounded_complete(
             semaphore,
             llm=self._llm,
             system_message=build_map_system_message(output_language),
@@ -1035,7 +972,7 @@ class Orchestrator:
         tenant_id: str,
         deadline: datetime,
         semaphore: asyncio.Semaphore,
-        timing: _SlotTiming | None = None,
+        timing: SlotTiming | None = None,
     ) -> float | None:
         """Leaf-judge a partial against its own (anonymised) chunk.
 
@@ -1059,7 +996,7 @@ class Orchestrator:
                 analyst_prompt=analyst_prompt,
                 analysis=partial,
             )
-            judge_response = await self._bounded_complete(
+            judge_response = await self._executor.bounded_complete(
                 semaphore,
                 llm=self._judge_llm,
                 system_message=judge_system,
@@ -1125,7 +1062,7 @@ class Orchestrator:
 
         async def _reduce_once(items: tuple[str, ...]) -> str:
             """Synthesise ``items`` (with the trend table) in one reduce call."""
-            response = await self._bounded_complete(
+            response = await self._executor.bounded_complete(
                 semaphore,
                 llm=self._llm,
                 system_message=system_message,
@@ -1269,7 +1206,7 @@ class Orchestrator:
             user_message
         )
 
-        timeout = self._check_deadline_and_get_timeout(deadline)
+        timeout = self._executor.check_deadline_and_get_timeout(deadline)
         response = await self._llm.complete(
             system_message=system_message,
             user_message=anonymized_user_message,
@@ -1283,7 +1220,7 @@ class Orchestrator:
             anonymized_user_message, response.structured.summary
         )
 
-        judge_timeout = self._check_deadline_and_get_timeout(deadline)
+        judge_timeout = self._executor.check_deadline_and_get_timeout(deadline)
         judge_response = await self._judge_llm.complete(
             system_message=judge_system,
             user_message=_JUDGE_USER_MESSAGE,
@@ -1338,7 +1275,7 @@ class Orchestrator:
             When the LLM returns invalid output or another non-recoverable
             error occurs.
         """
-        timeout = self._check_deadline_and_get_timeout(deadline)
+        timeout = self._executor.check_deadline_and_get_timeout(deadline)
         system_message = _DEFAULT_SUMMARIZATION_PROMPT
 
         user_message = build_feedback_record_envelope(
@@ -1363,7 +1300,7 @@ class Orchestrator:
             anonymized_user_message,
             llm_completion.structured.feedback_record_summaries[0].summary,
         )
-        judge_timeout = self._check_deadline_and_get_timeout(deadline)
+        judge_timeout = self._executor.check_deadline_and_get_timeout(deadline)
         judge_response = await self._judge_llm.complete(
             system_message=judge_system,
             user_message=_JUDGE_USER_MESSAGE,
@@ -1507,7 +1444,7 @@ class Orchestrator:
         SensitivityAnalysisResultModel
             The sensitivity analysis result for the feedback record.
         """
-        timeout = self._check_deadline_and_get_timeout(deadline)
+        timeout = self._executor.check_deadline_and_get_timeout(deadline)
         system_message = _DEFAULT_SENSITIVITY_DETECTION_PROMPT
         user_message = build_feedback_record_envelope(
             request.feedback_record, include_metadata=True, include_id=True
@@ -1539,28 +1476,6 @@ class Orchestrator:
             sensitivity_types=raw.sensitivity_types if raw else (),
             explanation=raw.explanation if raw else "No sensitive content detected.",
         )
-
-    def _check_deadline_and_get_timeout(self, deadline: datetime) -> float:
-        """Raise if the deadline has passed or too little time remains.
-
-        Return a timeout (seconds) bounded by the deadline and the
-        configured per-call limit.
-        """
-        remaining = (deadline - datetime.now(UTC)).total_seconds()
-        if remaining <= 0:
-            raise AnalysisTimeoutError("Deadline exceeded")
-        if remaining < _MINIMUM_ATTEMPT_WINDOW:
-            raise AnalysisTimeoutError(
-                f"Insufficient time remaining ({remaining:.1f}s) for an LLM attempt"
-            )
-        # A single ``LLMPort.complete`` may retry internally, spending up to
-        # ``LLM_RETRY_BUDGET_MULTIPLIER`` times this per-attempt timeout in worst
-        # case (see ``qfa.adapters.llm_client``). Divide the remaining deadline
-        # by the same factor so even a fully-retried last call finishes before
-        # the deadline. With a generous deadline the per-call cap binds first, so
-        # this only bites as the deadline approaches.
-        per_attempt_budget = remaining / LLM_RETRY_BUDGET_MULTIPLIER
-        return min(self._llm_timeout_seconds, per_attempt_budget)
 
     def _check_coding_deadline(self, deadline: datetime) -> None:
         """Raise when the coding deadline is exceeded."""
@@ -1661,7 +1576,7 @@ class Orchestrator:
             return []
 
         self._check_coding_deadline(deadline)
-        self._check_token_limit(system_message, user_message)
+        self._executor.check_token_limit(system_message, user_message)
 
         anonymized_user_message, _ = self._anonymizer.anonymize(user_message)
 
@@ -1689,7 +1604,7 @@ class Orchestrator:
             path=path,
         )
         self._check_coding_deadline(deadline)
-        self._check_token_limit(system_message, user_message)
+        self._executor.check_token_limit(system_message, user_message)
         user_message, _ = self._anonymizer.anonymize(user_message)
         response = await self._llm.complete(
             system_message=system_message,
@@ -1700,35 +1615,3 @@ class Orchestrator:
         if not 0.0 <= response.structured.score <= 1.0:
             raise AnalysisError("LLM judge returned score outside 0.0-1.0")
         return response.structured
-
-    # ------------------------------------------------------------------
-    # Token estimation
-    # ------------------------------------------------------------------
-
-    def _check_token_limit(self, system_message: str, user_message: str) -> None:
-        """Estimate total tokens and raise if over the limit.
-
-        Parameters
-        ----------
-        system_message : str
-            The assembled system message.
-        user_message : str
-            The assembled user message containing the feedback records.
-
-        Raises
-        ------
-        FeedbackTooLargeError
-            When estimated tokens exceed the configured limit.
-        """
-        assembled_text = system_message + user_message
-        estimated_tokens = len(assembled_text) // self._settings.chars_per_token
-        if estimated_tokens > self._max_total_tokens:
-            msg = (
-                f"Estimated tokens ({estimated_tokens}) exceed limit "
-                f"({self._max_total_tokens})"
-            )
-            raise FeedbackTooLargeError(
-                msg,
-                estimated_tokens=estimated_tokens,
-                limit=self._max_total_tokens,
-            )

--- a/src/qfa/settings.py
+++ b/src/qfa/settings.py
@@ -10,10 +10,10 @@ from qfa.domain.models import TenantApiKey
 #: Worst-case retry budget of a single ``LLMPort.complete`` call, expressed as a
 #: multiple of the per-attempt ``timeout``. The LLM adapter retries transient
 #: failures (timeout, rate-limit) up to ``LLM_RETRY_BUDGET_MULTIPLIER * timeout``
-#: of wall-clock; the orchestrator divides the deadline-derived budget by the
+#: of wall-clock; ``LLMCallExecutor`` divides the deadline-derived budget by the
 #: same factor when sizing a per-attempt timeout, so even the worst-case retry
 #: sequence of the last call in a phase still finishes before the request
-#: deadline. The adapter and orchestrator MUST read this one constant so the two
+#: deadline. The adapter and the executor MUST read this one constant so the two
 #: stay in lock-step — they live in different layers and cannot share code.
 LLM_RETRY_BUDGET_MULTIPLIER: float = 3.0
 

--- a/tests/services/test_llm_call_executor.py
+++ b/tests/services/test_llm_call_executor.py
@@ -1,0 +1,393 @@
+"""Tests for :class:`~qfa.services.llm_call_executor.LLMCallExecutor`.
+
+Why: this collaborator is the shared LLM-call scaffolding every use-case
+service in ``qfa.services`` delegates to (ADR-017). Before this module its
+four behaviours were only reachable through ``Orchestrator``, so a change
+to the deadline arithmetic or the token estimate was verified indirectly,
+through whichever endpoint happened to exercise it. These tests pin them
+directly.
+
+Per ADR-017 the executor under test is the **real** one, constructed over
+the existing ``FakeLLMPort`` / ``FakeAnonymizer`` doubles from
+``test_orchestrator`` — there is no fake executor.
+"""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from qfa.domain.errors import (
+    AnalysisTimeoutError,
+    FeedbackTooLargeError,
+    LLMError,
+    LLMRateLimitError,
+    LLMTimeoutError,
+)
+from qfa.domain.models import (
+    FeedbackRecordMetadataModel,
+    FeedbackRecordModel,
+    LLMResponse,
+)
+from qfa.domain.ports import AnonymizationPort
+from qfa.services.llm_call_executor import LLMCallExecutor, SlotTiming
+from qfa.settings import LLM_RETRY_BUDGET_MULTIPLIER, OrchestratorSettings
+
+# Reuse the doubles the orchestrator suite already ships rather than growing a
+# second, drifting pair (ADR-017: service tests use the real executor over the
+# existing fake driven adapters).
+from .test_orchestrator import FakeAnonymizer, FakeLLMPort
+
+TENANT_ID = "tenant-42"
+LLM_TIMEOUT = 30.0
+MAX_TOKENS = 10_000
+
+
+class RedactingAnonymizer(AnonymizationPort):
+    """Anonymiser that actually redacts, so a round-trip is observable.
+
+    The shared ``FakeAnonymizer`` is a deliberate no-op, which cannot show
+    that ``anonymize_records`` returns a mapping capable of restoring the
+    original text.
+    """
+
+    def anonymize(self, text):
+        """Replace every occurrence of ``Jane`` with a PERSON placeholder."""
+        return text.replace("Jane", "<PERSON_0>"), {"<PERSON_0>": "Jane"}
+
+    def deanonymize(self, text, mapping):
+        """Substitute each placeholder in ``mapping`` back into ``text``."""
+        for placeholder, original in mapping.items():
+            text = text.replace(placeholder, original)
+        return text
+
+
+def _make_record(doc_id="doc-1", content="Some feedback text."):
+    return FeedbackRecordModel(
+        id=doc_id,
+        content=content,
+        metadata=FeedbackRecordMetadataModel.model_validate({}),
+        url_id="",
+    )
+
+
+def _make_response(structured="ok"):
+    return LLMResponse(
+        structured=structured,
+        model="fake",
+        prompt_tokens=10,
+        completion_tokens=5,
+        cost=0.0,
+    )
+
+
+def _make_executor(
+    llm=None,
+    anonymizer=None,
+    settings=None,
+    llm_timeout_seconds=LLM_TIMEOUT,
+    max_total_tokens=MAX_TOKENS,
+):
+    return LLMCallExecutor(
+        llm=llm if llm is not None else FakeLLMPort(responses=[_make_response()]),
+        anonymizer=anonymizer if anonymizer is not None else FakeAnonymizer(),
+        settings=settings or OrchestratorSettings(),
+        llm_timeout_seconds=llm_timeout_seconds,
+        max_total_tokens=max_total_tokens,
+    )
+
+
+def _future_deadline(seconds=300):
+    return datetime.now(tz=UTC) + timedelta(seconds=seconds)
+
+
+def _past_deadline():
+    return datetime.now(tz=UTC) - timedelta(seconds=10)
+
+
+async def _complete(executor, *, llm=None, deadline=None, timing=None, semaphore=None):
+    """Run one ``bounded_complete`` with the boilerplate defaulted away."""
+    return await executor.bounded_complete(
+        semaphore or asyncio.Semaphore(1),
+        llm=llm,
+        system_message="sys",
+        user_message="user",
+        tenant_id=TENANT_ID,
+        response_model=str,
+        deadline=deadline or _future_deadline(),
+        timing=timing,
+    )
+
+
+class TestCheckDeadlineAndGetTimeout:
+    def test_generous_deadline_yields_the_per_call_cap(self):
+        executor = _make_executor()
+
+        # 300s remaining / 3.0 = 100s of per-attempt budget, so the configured
+        # per-call ceiling is the binding constraint.
+        assert executor.check_deadline_and_get_timeout(
+            _future_deadline(300)
+        ) == pytest.approx(LLM_TIMEOUT)
+
+    def test_tight_deadline_reserves_the_adapter_retry_budget(self):
+        """The returned window leaves room for the adapter's internal retries.
+
+        ``LLMPort.complete`` may retry a transient failure up to
+        ``LLM_RETRY_BUDGET_MULTIPLIER`` times its timeout, so the deadline-derived
+        budget is divided by the same factor. Without that division a
+        fully-retried last call would overrun the request deadline.
+        """
+        executor = _make_executor()
+        remaining = 60.0
+
+        timeout = executor.check_deadline_and_get_timeout(_future_deadline(remaining))
+
+        assert timeout == pytest.approx(
+            remaining / LLM_RETRY_BUDGET_MULTIPLIER, abs=0.5
+        )
+        assert timeout < LLM_TIMEOUT
+
+    def test_expired_deadline_raises(self):
+        executor = _make_executor()
+
+        with pytest.raises(AnalysisTimeoutError, match="Deadline exceeded"):
+            executor.check_deadline_and_get_timeout(_past_deadline())
+
+    def test_insufficient_remaining_time_raises(self):
+        """A window too short for any attempt fails fast instead of calling out."""
+        executor = _make_executor()
+
+        with pytest.raises(AnalysisTimeoutError, match="Insufficient time remaining"):
+            executor.check_deadline_and_get_timeout(_future_deadline(5))
+
+
+class TestCheckTokenLimit:
+    def test_within_budget_passes(self):
+        executor = _make_executor(max_total_tokens=MAX_TOKENS)
+
+        executor.check_token_limit("system", "user")  # no raise
+
+    def test_over_budget_is_rejected_with_the_estimate_and_limit(self):
+        settings = OrchestratorSettings()
+        executor = _make_executor(settings=settings, max_total_tokens=10)
+        # 10 * chars_per_token characters lands exactly on the limit, so one
+        # extra chars_per_token block puts the estimate over it.
+        user_message = "x" * (11 * settings.chars_per_token)
+
+        with pytest.raises(FeedbackTooLargeError) as exc_info:
+            executor.check_token_limit("", user_message)
+
+        assert exc_info.value.limit == 10
+        assert exc_info.value.estimated_tokens == 11
+
+    def test_boundary_estimate_is_allowed(self):
+        """Exactly at the limit is accepted; only *over* the limit raises."""
+        settings = OrchestratorSettings()
+        executor = _make_executor(settings=settings, max_total_tokens=10)
+
+        executor.check_token_limit("", "x" * (10 * settings.chars_per_token))
+
+
+class TestAnonymizeRecords:
+    def test_round_trips_through_the_returned_mapping(self):
+        anonymizer = RedactingAnonymizer()
+        executor = _make_executor(anonymizer=anonymizer)
+        records = (
+            _make_record("doc-1", "Jane reported a leak."),
+            _make_record("doc-2", "Jane again, plus a clinic queue."),
+        )
+
+        anonymized, mapping = executor.anonymize_records(records, anonymize=True)
+
+        assert [r.content for r in anonymized] == [
+            "<PERSON_0> reported a leak.",
+            "<PERSON_0> again, plus a clinic queue.",
+        ]
+        # The merged mapping restores every redacted record.
+        assert [anonymizer.deanonymize(r.content, mapping) for r in anonymized] == [
+            r.content for r in records
+        ]
+
+    def test_leaves_metadata_and_ids_untouched(self):
+        executor = _make_executor(anonymizer=RedactingAnonymizer())
+        records = (_make_record("doc-1", "Jane reported a leak."),)
+
+        anonymized, _ = executor.anonymize_records(records, anonymize=True)
+
+        assert anonymized[0].id == "doc-1"
+        assert anonymized[0].metadata == records[0].metadata
+
+    def test_disabled_returns_the_records_unchanged(self):
+        executor = _make_executor(anonymizer=RedactingAnonymizer())
+        records = (_make_record("doc-1", "Jane reported a leak."),)
+
+        anonymized, mapping = executor.anonymize_records(records, anonymize=False)
+
+        assert anonymized is records
+        assert mapping == {}
+
+
+class TestBoundedComplete:
+    @pytest.mark.asyncio
+    async def test_passes_the_deadline_derived_timeout_to_the_port(self):
+        fake_llm = FakeLLMPort(responses=[_make_response("done")])
+        executor = _make_executor(llm=fake_llm)
+
+        response = await _complete(executor, llm=fake_llm)
+
+        assert response.structured == "done"
+        assert fake_llm.calls[0]["timeout"] == pytest.approx(LLM_TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_the_executors_own_client(self):
+        """Omitting ``llm`` uses the connection the executor was built over."""
+        primary = FakeLLMPort(responses=[_make_response("primary")])
+        executor = _make_executor(llm=primary)
+
+        response = await _complete(executor)
+
+        assert response.structured == "primary"
+        assert len(primary.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_explicit_client_overrides_the_default(self):
+        """Judge calls run on their own connection without touching the primary."""
+        primary = FakeLLMPort(responses=[_make_response("primary")])
+        judge = FakeLLMPort(responses=[_make_response("judge")])
+        executor = _make_executor(llm=primary)
+
+        response = await _complete(executor, llm=judge)
+
+        assert response.structured == "judge"
+        assert primary.calls == []
+        assert len(judge.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_expired_deadline_raises_before_calling_the_llm(self):
+        fake_llm = FakeLLMPort(responses=[_make_response()])
+        executor = _make_executor(llm=fake_llm)
+
+        with pytest.raises(AnalysisTimeoutError):
+            await _complete(executor, llm=fake_llm, deadline=_past_deadline())
+
+        assert fake_llm.calls == []
+
+    @pytest.mark.asyncio
+    async def test_deadline_that_expires_during_queue_wait_is_honoured(self):
+        """The timeout is derived *after* the slot is acquired, not before.
+
+        A call that queued behind others must not spend a window that elapsed
+        while it waited — the queued call is abandoned, not issued.
+        """
+        fake_llm = FakeLLMPort(responses=[_make_response()])
+        executor = _make_executor(llm=fake_llm)
+        semaphore = asyncio.Semaphore(1)
+        await semaphore.acquire()
+
+        queued = asyncio.create_task(
+            _complete(
+                executor,
+                llm=fake_llm,
+                deadline=_past_deadline(),
+                semaphore=semaphore,
+            )
+        )
+        # Let the task reach the semaphore before the slot frees up.
+        await asyncio.sleep(0)
+        semaphore.release()
+
+        with pytest.raises(AnalysisTimeoutError):
+            await queued
+        assert fake_llm.calls == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error",
+        [
+            LLMTimeoutError("upstream timed out"),
+            LLMRateLimitError("429 from provider"),
+        ],
+    )
+    async def test_transient_errors_propagate_without_a_second_attempt(self, error):
+        """Retrying transient failures is the adapter's job, not the executor's.
+
+        ``LiteLLMClient`` retries with backoff inside one ``complete`` call; the
+        executor reserves wall-clock for that (see
+        ``check_deadline_and_get_timeout``) but must not add a retry loop of its
+        own, which would multiply the budget it just divided.
+        """
+        fake_llm = FakeLLMPort(errors=[error])
+        executor = _make_executor(llm=fake_llm)
+
+        with pytest.raises(type(error)):
+            await _complete(executor, llm=fake_llm)
+
+        assert len(fake_llm.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_non_transient_error_passes_straight_through(self):
+        fake_llm = FakeLLMPort(errors=[LLMError("internal server error")])
+        executor = _make_executor(llm=fake_llm)
+
+        with pytest.raises(LLMError, match="internal server error"):
+            await _complete(executor, llm=fake_llm)
+
+        assert len(fake_llm.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_semaphore_bounds_concurrent_calls(self):
+        """``cap=1`` serialises the calls; nothing runs two at once."""
+        in_flight = 0
+        peak = 0
+
+        class CountingLLM(FakeLLMPort):
+            async def complete(self, *args, **kwargs):
+                nonlocal in_flight, peak
+                in_flight += 1
+                peak = max(peak, in_flight)
+                try:
+                    await asyncio.sleep(0)
+                    return await super().complete(*args, **kwargs)
+                finally:
+                    in_flight -= 1
+
+        fake_llm = CountingLLM(responses=[_make_response() for _ in range(4)])
+        executor = _make_executor(llm=fake_llm)
+        semaphore = asyncio.Semaphore(1)
+
+        await asyncio.gather(
+            *(_complete(executor, llm=fake_llm, semaphore=semaphore) for _ in range(4))
+        )
+
+        assert peak == 1
+        assert len(fake_llm.calls) == 4
+
+    @pytest.mark.asyncio
+    async def test_timing_separates_queue_wait_from_call_time(self):
+        """Queue-wait is reported apart from the call, so logs stay honest."""
+        fake_llm = FakeLLMPort(responses=[_make_response()])
+        executor = _make_executor(llm=fake_llm)
+        semaphore = asyncio.Semaphore(1)
+        timing = SlotTiming()
+        await semaphore.acquire()
+
+        queued = asyncio.create_task(
+            _complete(executor, llm=fake_llm, timing=timing, semaphore=semaphore)
+        )
+        await asyncio.sleep(0.02)
+        semaphore.release()
+        await queued
+
+        assert timing.queued_seconds >= 0.02
+        assert timing.call_seconds < timing.queued_seconds
+
+    @pytest.mark.asyncio
+    async def test_timing_is_populated_even_when_the_call_fails(self):
+        fake_llm = FakeLLMPort(errors=[LLMError("boom")])
+        executor = _make_executor(llm=fake_llm)
+        timing = SlotTiming()
+
+        with pytest.raises(LLMError):
+            await _complete(executor, llm=fake_llm, timing=timing)
+
+        assert timing.call_seconds > 0.0


### PR DESCRIPTION
Tree is clean, one commit on `feat/262-loop-refactor-services-extract-llmcallexecuto`.

## PR-ready summary

**refactor(services): extract LLMCallExecutor collaborator from Orchestrator** — closes #262

### What changed

New `src/qfa/services/llm_call_executor.py` holds `class LLMCallExecutor:` (no base class, no `Protocol`, not referenced from `qfa/domain/ports.py`) with the four LLM-call helpers that were spread across `Orchestrator`'s privates, renamed to public names now that the calls are cross-class:

| Was on `Orchestrator` | Now on `LLMCallExecutor` |
|---|---|
| `_anonymize_records` | `anonymize_records` |
| `_bounded_complete` | `bounded_complete` |
| `_check_deadline_and_get_timeout` | `check_deadline_and_get_timeout` |
| `_check_token_limit` | `check_token_limit` |

Constructor takes `llm`, `anonymizer`, `settings`, `llm_timeout_seconds`, `max_total_tokens`. `_SlotTiming` moved with `bounded_complete` and became public `SlotTiming` — it is now a cross-module signature type. `_MINIMUM_ATTEMPT_WINDOW` moved and stayed private to the new module.

`Orchestrator` holds `self._executor` and delegates at all 13 call sites; the four methods are deleted from it (1734 → 1617 lines). `build_orchestrator` constructs the executor and passes it in; its own signature is unchanged.

Two judgement calls worth a reviewer's eye:

- **`executor` is an optional constructor argument**, default-constructed from the ports `Orchestrator` already receives. There are ~60 `Orchestrator(...)` sites across tests, `scripts/`, and notebooks; making it required would churn all of them for no behavioural gain, and the spec's AC bounds test changes to how the orchestrator under test is constructed. The composition root injects explicitly, per ADR-017; everyone else gets an equivalent one for free. `tests/services/test_orchestrator.py` and `test_orchestrator_hierarchical.py` needed **zero** changes as a result.
- **`bounded_complete`'s `llm` argument is now optional**, defaulting to the connection the executor was built over. The spec requires `llm` in the constructor, but none of the four moved methods used `self._llm` — this makes it load-bearing rather than vestigial. Every existing call site still passes `llm=` explicitly, so judge calls stay visibly routed to the judge connection and behaviour is identical.

### Tests

New `tests/services/test_llm_call_executor.py` (21 tests) drives the **real** executor over the existing `FakeLLMPort` / `FakeAnonymizer` doubles imported from `test_orchestrator` — no fake executor. Covers deadline expiry and the insufficient-window guard, retry-budget reservation (`remaining / LLM_RETRY_BUDGET_MULTIPLIER`), transient errors (`LLMTimeoutError`/`LLMRateLimitError`) propagating with exactly one attempt, non-transient `LLMError` passthrough, token-limit rejection with `estimated_tokens`/`limit` plus the at-limit boundary, anonymize→deanonymize round-tripping, the primary/override client split, semaphore bounding, and timing capture (including the deadline-expires-during-queue-wait case, which pins that the timeout is derived *after* slot acquisition).

One test double was added: `RedactingAnonymizer` — the shared `FakeAnonymizer` is a deliberate no-op, so it cannot demonstrate a round-trip. It inherits `AnonymizationPort` per AGENTS.md.

### Docs

`docs/architecture/03-components.md` gains a "The LLM-call executor" subsection (method table, why it's neither port nor base class, primary-vs-judge connection) and the composition-root bullet now names the executor. `docs/architecture/04-crosscutting.md`: the deadline-check row now attributes the concern to the executor, plus a note on batch vs single-message redaction. `docs/development/implementing-a-new-endpoint.md`: the worked example calls `self._executor.check_deadline_and_get_timeout(...)`, with a paragraph telling authors to reuse the executor rather than re-derive the arithmetic. `qfa.settings.LLM_RETRY_BUDGET_MULTIPLIER`'s comment now names the executor as the constant's second reader.

### Impact / risk

Low. Behaviour-preserving refactor: all six public method signatures verified byte-identical against `HEAD`, no HTTP request/response shape, status code, or error payload change, no route or DI change. `make test` — 613 passed. `make lint` — ruff, `ty`, and all three import-linter contracts pass. `make docs` builds clean under `-W`.

The main residual risk is the coexistence window ADR-017 anticipates: `Orchestrator` still calls `self._llm` / `self._anonymizer` directly in the paths that were not part of the four moved helpers, so the executor is not yet the sole route to the LLM. That converges in #263–#267. A caller that injects an executor built over a *different* LLM than the orchestrator's would get divergent routing — the composition root doesn't, and the docstring flags it.

Fixes #262

~Written by Claude, run via the agentic engineering loop