### PR TITLE
refactor(services): extract SensitivityService from Orchestrator

### DIFF
--- a/docs/architecture/03-components.md
+++ b/docs/architecture/03-components.md
@@ -97,7 +97,7 @@ the rationale, and flow/sequence diagrams.
 
 ## The orchestrator
 
-{py:class}`~qfa.services.orchestrator.Orchestrator` is one class with five async methods, each backing one HTTP endpoint:
+{py:class}`~qfa.services.orchestrator.Orchestrator` is one class with four async methods, each backing one HTTP endpoint:
 
 | Method | Endpoint | What it does |
 |---|---|---|
@@ -105,22 +105,40 @@ the rationale, and flow/sequence diagrams.
 | `analyze_hierarchical` | `POST /v1/analyze` (`mode=hierarchical`) | Embed -> cluster -> map -> reduce pipeline. Returns additional `confidence` and `coding_trends` fields. |
 | `summarize` | `POST /v1/summarize` | One LLM call. Per-record summaries with a self-evaluated quality score. |
 | `assign_codes` | `POST /v1/assign-codes` | Multiple LLM calls per record: pick + judge at each level of a hierarchical coding framework. |
-| `detect_sensitive_content` | `POST /v1/detect-sensitive` | One LLM call per record. Detects sensitive content and categorizes sensitivity types. |
+
+It is being decomposed into one service per use case by epic #112, so this
+table shrinks by one row per extraction and the class disappears entirely at
+the end of it. The extracted services are listed below.
 
 `/v1/summarize`, `/v1/assign-codes`, and `/v1/detect-sensitive` are non-bulk endpoints with per-record outputs. `/v1/analyze` is the bulk endpoint and returns one aggregate result per request (for both `mode=single_pass` and `mode=hierarchical`).
 
 Each method is pure use-case logic — no scope or correlation plumbing. `call_scope` is entered by a FastAPI dependency declared on the route (`Depends(call_scope_for(Operation.X))`), so by the time an orchestrator method runs `current_call_context` is already set. See [Cross-cutting concerns](04-crosscutting.md) for the full picture.
 
+### Extracted use-case services
+
+Each service below is a plain class in `qfa.services` that owns exactly one use
+case, receives the shared {py:class}`~qfa.services.llm_call_executor.LLMCallExecutor`
+as a constructor dependency, and is injected into its route by its own provider in
+`qfa.api.dependencies`. None of them has a base class — see
+[ADR-017](../adr/017-orchestrator-composition-only.md).
+
+| Service | Endpoint | Provider | What it does |
+|---|---|---|---|
+| {py:class}`~qfa.services.sensitivity.SensitivityService` | `POST /v1/detect-sensitive` | `get_sensitivity_service` | One LLM call per record. Detects sensitive content and categorizes sensitivity types. |
+
 ### The LLM-call executor
 
-The scaffolding every use case wraps its LLM calls in lives on one collaborator, {py:class}`~qfa.services.llm_call_executor.LLMCallExecutor`, which the orchestrator holds as `self._executor` and delegates to:
+The scaffolding every use case wraps its LLM calls in lives on one collaborator, {py:class}`~qfa.services.llm_call_executor.LLMCallExecutor`, which the orchestrator and every extracted service hold as `self._executor` and delegate to:
 
 | Method | Concern |
 |---|---|
 | `check_deadline_and_get_timeout(deadline)` | Derive the per-call timeout from the remaining request budget; raise {py:exc}`~qfa.domain.errors.AnalysisTimeoutError` when too little time is left |
 | `check_token_limit(system_message, user_message)` | Pre-flight token estimate; raise {py:exc}`~qfa.domain.errors.FeedbackTooLargeError` when over `LLM_MAX_TOTAL_TOKENS` |
 | `anonymize_records(records, anonymize)` | Redact each record's text, returning new records plus the merged restore mapping |
-| `bounded_complete(semaphore, …)` | One completion bounded by both a concurrency semaphore and the deadline; used by the hierarchical map/judge/reduce phases |
+| `anonymize_text(text)` | Redact one assembled message, returning the redacted text plus its restore mapping |
+| `deanonymize_json(payload, mapping)` | Restore redacted values inside a serialized JSON response, escaping them so the payload stays valid JSON |
+| `complete(…)` | One completion bounded by the deadline; used by the single-call use cases |
+| `bounded_complete(semaphore, …)` | `complete` run under a concurrency semaphore, with queue-wait timing; used by the hierarchical map/judge/reduce phases |
 
 It is a **plain concrete class** — not a Protocol, not a base class, and not declared in `qfa.domain.ports`. It wraps no external system, so it is not a port; and behaviour reuse in this codebase is always composition, so nothing inherits from it. Both points are decided in [ADR-017: Decompose the Orchestrator by composition only](../adr/017-orchestrator-composition-only.md), which is also why the composition root injects the executor rather than letting the service construct its own.
 
@@ -133,11 +151,11 @@ Tests construct the real executor over the existing `FakeLLMPort` / `FakeAnonymi
 `qfa.api.app.create_app()` builds the FastAPI instance; the `lifespan` context manager wires the dependency graph at startup. The wiring splits into two halves:
 
 - **Infrastructure half** (in `qfa.api.app`): load settings, build the base LLM client — plus a second one for judge calls when `JUDGE_LLM_MODEL` is set — create the async DB engine, wrap each LLM in {py:class}`~qfa.adapters.tracking_llm.TrackingLLMAdapter` for usage tracking, set up the auth adapter, build the embedder (logging its construction so operators see it on startup).
-- **Domain half** (in {py:func}`qfa.api.composition.build_orchestrator`): given settings plus the already-wrapped LLM and embedder, construct the {py:class}`~qfa.adapters.presidio_anonymizer.PresidioAnonymizer` and the {py:class}`~qfa.services.llm_call_executor.LLMCallExecutor`, register custom model prices with LiteLLM, and assemble the {py:class}`~qfa.services.orchestrator.Orchestrator`.
+- **Domain half** (in {py:func}`qfa.api.composition.build_services`): given settings plus the already-wrapped LLM and embedder, construct the {py:class}`~qfa.adapters.presidio_anonymizer.PresidioAnonymizer` and the {py:class}`~qfa.services.llm_call_executor.LLMCallExecutor`, register custom model prices with LiteLLM, and assemble every application service — returned together as a {py:class}`~qfa.api.composition.ServiceGraph` so they share the one executor.
 
-The lifespan then attaches the orchestrator, API keys, and the usage repository to `app.state` for the request lifecycle to read.
+The lifespan then attaches each service (`app.state.orchestrator`, `app.state.sensitivity_service`), the API keys, and the usage repository to `app.state` for the request lifecycle to read. One `app.state` slot per service is what lets each route's provider inject only the use case it needs.
 
-The split exists so callers outside the API server — scripts, notebooks, ad-hoc evaluation harnesses — can construct an `Orchestrator` over a plain LLM client with a single call:
+The split exists so callers outside the API server — scripts, notebooks, ad-hoc evaluation harnesses — can construct an `Orchestrator` over a plain LLM client with a single call ({py:func}`~qfa.api.composition.build_orchestrator` is the narrow wrapper over `build_services` for exactly that case):
 
 ```python
 from qfa.api.composition import build_orchestrator

--- a/docs/development/implementing-a-new-endpoint.md
+++ b/docs/development/implementing-a-new-endpoint.md
@@ -255,6 +255,18 @@ inference route:
 - `get_orchestrator` injects the orchestrator wired at startup.
 - `call_scope_for(Operation.CLASSIFY)` opens the usage-tracking scope (step 7).
 
+```{note}
+`Orchestrator` is being decomposed into one service per use case
+([ADR-017](../adr/017-orchestrator-composition-only.md)). A *new* use case is
+a new class in `qfa.services` taking an `LLMCallExecutor` (plus whatever else
+it needs), built in {py:func}`qfa.api.composition.build_services`, published on
+its own `app.state` slot, and injected by its own provider in
+`qfa.api.dependencies` — see {py:class}`~qfa.services.sensitivity.SensitivityService`
+and `get_sensitivity_service` for the worked example. Annotate the handler
+against that service instead of `Orchestrator`; the rest of this page is
+unchanged.
+```
+
 The route is also where the API ↔ domain mapping happens — never pass an API
 schema into the orchestrator, and never return a domain model from the route.
 API value objects are mapped to their domain equivalents here too: the

--- a/spec/issue-263.md
+++ b/spec/issue-263.md
@@ -1,0 +1,36 @@
+Part of the `Orchestrator` decomposition epic (#112). This is the smallest extraction and
+lands first among the four, as the end-to-end proof of the pattern.
+
+Depends-on: #262
+
+## Spec
+
+**What:** Extract `Orchestrator.detect_sensitive_content` (~50 lines, currently around
+line 1385) into `SensitivityService` in `src/qfa/services/sensitivity.py`, add a
+`get_sensitivity_service` DI provider, and repoint the sensitivity route
+(`src/qfa/api/routes.py`, ~line 512) at it.
+
+**Why:** `detect_sensitive_content` is the smallest and most self-contained of the six use
+cases — one LLM call, no helper methods, no embedder. That makes it the cheapest possible
+first full traversal of the pattern: new service class → DI provider → route rewire →
+tests moved → composition updated. Any friction in the approach (import-linter
+complaints, DI wiring awkwardness, test-fixture churn) surfaces here on a 50-line change
+rather than on the 700-line `AnalyzeService`. The three larger extractions then copy a
+proven shape.
+
+## Acceptance criteria
+
+- [ ] `src/qfa/services/sensitivity.py` defines `class SensitivityService:` with **no
+      base class**, taking an `LLMCallExecutor` as a constructor dependency.
+- [ ] `detect_sensitive_content` is moved onto it and **deleted** from `Orchestrator`.
+- [ ] `get_sensitivity_service` is added to `src/qfa/api/dependencies.py`.
+- [ ] The sensitivity route handler type-annotates against `SensitivityService` and no
+      longer takes `Orchestrator`.
+- [ ] `src/qfa/api/composition.py` constructs the service (sharing the one
+      `LLMCallExecutor` instance with the still-present `Orchestrator`).
+- [ ] Tests for this use case move to `tests/services/test_sensitivity.py`, constructing
+      the real `LLMCallExecutor` over `FakeLLMPort` / `FakeAnonymizer`. No test assertion
+      is weakened or deleted in the move.
+- [ ] The existing e2e/API tests for the sensitivity endpoint pass **unmodified** —
+      response shape, status codes, and error payloads are unchanged.
+- [ ] `make test` and `make lint` pass, including all three `import-linter` contracts.

--- a/src/qfa/api/app.py
+++ b/src/qfa/api/app.py
@@ -24,7 +24,7 @@ from qfa.adapters.tracking_llm import TrackingLLMAdapter
 from qfa.adapters.usage_repository import SqlAlchemyUsageRepository
 from qfa.api.composition import (
     build_embedder,
-    build_orchestrator,
+    build_services,
     resolve_judge_llm_settings,
 )
 from qfa.api.routes import router
@@ -609,13 +609,14 @@ def _make_lifespan(llm_factory: LLMFactory):
            ``TrackingLLMAdapter`` so every call attempt is recorded —
            an unwrapped judge client would omit judge calls from usage.
         4. Build the embedder here (rather than inside
-           ``build_orchestrator``) so its construction is visible in
+           ``build_services``) so its construction is visible in
            startup logs before any traffic arrives.
-        5. Delegate to :func:`qfa.api.composition.build_orchestrator`
-           to assemble the orchestrator — it also registers custom
-           LiteLLM model prices needed for ``completion_cost()``.
-        6. Publish ``orchestrator``, ``api_keys``, ``settings``, and
-           ``usage_repo`` on ``app.state`` for routes/middleware to read.
+        5. Delegate to :func:`qfa.api.composition.build_services`
+           to assemble the application services — it also registers
+           custom LiteLLM model prices needed for ``completion_cost()``.
+        6. Publish ``orchestrator``, ``sensitivity_service``,
+           ``api_keys``, ``settings``, and ``usage_repo`` on
+           ``app.state`` for routes/middleware to read.
 
         On shutdown the only resource that needs explicit cleanup is the
         DB engine's connection pool; everything else is plain Python
@@ -672,7 +673,7 @@ def _make_lifespan(llm_factory: LLMFactory):
         if embedder is not None:
             logger.info("Embedding model ready (hierarchical analysis available)")
 
-        orchestrator = build_orchestrator(
+        services = build_services(
             settings,
             llm=llm_for_orch,
             judge_llm=judge_for_orch,
@@ -686,7 +687,10 @@ def _make_lifespan(llm_factory: LLMFactory):
             ],
             auth_management_port=auth_adapter,
         )
-        app.state.orchestrator = orchestrator
+        app.state.orchestrator = services.orchestrator
+        # One provider per use-case service (ADR-017): each route reads the
+        # single service it needs off app.state.
+        app.state.sensitivity_service = services.sensitivity
         app.state.settings = settings
         app.state.usage_repo = usage_repo
 

--- a/src/qfa/api/composition.py
+++ b/src/qfa/api/composition.py
@@ -1,11 +1,15 @@
-"""Composition helpers for constructing an :class:`Orchestrator`.
+"""Composition helpers for constructing the application services.
 
 This module is the *domain-graph* half of the composition root. The
 FastAPI lifespan in :mod:`qfa.api.app` still owns *infrastructure*
 wiring (database engine, usage repository, ``TrackingLLMAdapter``,
 ``app.state`` attachment, logging setup) but delegates the construction
-of the :class:`Orchestrator` itself — together with its driven adapters
+of the services themselves — together with their driven adapters
 that don't require the database — to this module.
+
+:func:`build_services` returns every application service as a
+:class:`ServiceGraph`; :func:`build_orchestrator` is the narrower entry
+point for callers that only want the (shrinking) :class:`Orchestrator`.
 
 Why it lives here rather than at package root:
 
@@ -25,11 +29,12 @@ via the ``llm`` keyword argument. Callers that don't (scripts,
 notebooks, ad-hoc evaluation harnesses) call ``build_orchestrator``
 with no overrides and get an Orchestrator over a plain LiteLLM client.
 
-Besides the driven adapters, this module also builds the
-:class:`~qfa.services.llm_call_executor.LLMCallExecutor` the orchestrator
+Besides the driven adapters, this module also builds the one
+:class:`~qfa.services.llm_call_executor.LLMCallExecutor` every service
 delegates its LLM-call scaffolding to. Per ADR-017 that collaborator is
 *injected*, not self-constructed, so the composition root stays the one
-place where the object graph is assembled.
+place where the object graph is assembled — and every service shares a
+single instance of it.
 
 The orchestrator may hold *two* LLM connections: the primary one used for
 generation, and an optional second one used only for judge calls, configured
@@ -41,6 +46,7 @@ from __future__ import annotations
 
 import importlib.resources
 import logging
+from dataclasses import dataclass
 
 import litellm
 import yaml
@@ -50,9 +56,34 @@ from qfa.adapters.presidio_anonymizer import PresidioAnonymizer
 from qfa.domain.ports import EmbeddingPort, LLMPort
 from qfa.services.llm_call_executor import LLMCallExecutor
 from qfa.services.orchestrator import Orchestrator
+from qfa.services.sensitivity import SensitivityService
 from qfa.settings import AppSettings, EmbeddingSettings, JudgeLLMSettings, LLMSettings
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ServiceGraph:
+    """The application services the API publishes on ``app.state``.
+
+    Epic #112 splits ``Orchestrator`` into one service per use case, so the
+    composition root now returns more than one object. Grouping them keeps
+    the shared parts of the graph — notably the single
+    :class:`~qfa.services.llm_call_executor.LLMCallExecutor` — built once,
+    and gives the lifespan one thing to construct and unpack. It grows one
+    field per extraction and loses ``orchestrator`` when the class is
+    deleted (#267).
+
+    Attributes
+    ----------
+    orchestrator : Orchestrator
+        The still-undecomposed use cases (analyze, summarize, coding).
+    sensitivity : SensitivityService
+        The detect-sensitive use case, extracted in #263.
+    """
+
+    orchestrator: Orchestrator
+    sensitivity: SensitivityService
 
 
 def resolve_judge_llm_settings(
@@ -164,20 +195,25 @@ def register_custom_model_prices() -> None:
         )
 
 
-def build_orchestrator(
+def build_services(
     settings: AppSettings,
     *,
     llm: LLMPort | None = None,
     judge_llm: LLMPort | None = None,
     embedder: EmbeddingPort | None = None,
-) -> Orchestrator:
-    """Construct an :class:`Orchestrator` from application settings.
+) -> ServiceGraph:
+    """Construct the application services from application settings.
 
     This is the shared composition point used by both the FastAPI
     lifespan and out-of-process callers (scripts, notebooks). It owns
-    the construction of the orchestrator's driven dependencies that do
+    the construction of the services' driven dependencies that do
     not require a database connection: the anonymiser, the LLM client
     (when not overridden), and the optional embedder.
+
+    Every service is built over the *same*
+    :class:`~qfa.services.llm_call_executor.LLMCallExecutor`, so the
+    per-call timeout, the token ceiling and the anonymiser are configured
+    once for the whole graph rather than per use case.
 
     Parameters
     ----------
@@ -216,9 +252,8 @@ def build_orchestrator(
 
     Returns
     -------
-    Orchestrator
-        A fully wired orchestrator ready for ``analyze`` /
-        ``analyze_hierarchical`` calls.
+    ServiceGraph
+        The fully wired services, ready to be published on ``app.state``.
     """
     register_custom_model_prices()
 
@@ -256,14 +291,53 @@ def build_orchestrator(
         max_total_tokens=settings.llm.max_total_tokens,
     )
 
-    return Orchestrator(
-        llm=llm,
-        judge_llm=judge_llm,
-        anonymizer=anonymizer,
-        settings=settings.orchestrator,
-        analyze_settings=settings.analyze,
-        llm_timeout_seconds=settings.llm.timeout_seconds,
-        max_total_tokens=settings.llm.max_total_tokens,
-        embedder=embedder,
-        executor=executor,
+    return ServiceGraph(
+        orchestrator=Orchestrator(
+            llm=llm,
+            judge_llm=judge_llm,
+            anonymizer=anonymizer,
+            settings=settings.orchestrator,
+            analyze_settings=settings.analyze,
+            llm_timeout_seconds=settings.llm.timeout_seconds,
+            max_total_tokens=settings.llm.max_total_tokens,
+            embedder=embedder,
+            executor=executor,
+        ),
+        sensitivity=SensitivityService(executor=executor),
     )
+
+
+def build_orchestrator(
+    settings: AppSettings,
+    *,
+    llm: LLMPort | None = None,
+    judge_llm: LLMPort | None = None,
+    embedder: EmbeddingPort | None = None,
+) -> Orchestrator:
+    """Construct just the :class:`Orchestrator` from application settings.
+
+    A thin wrapper over :func:`build_services` for the callers that only
+    want the orchestrator — scripts, notebooks and evaluation harnesses,
+    which run one use case in-process and have no ``app.state`` to publish
+    the rest onto. The FastAPI lifespan calls ``build_services`` instead.
+
+    Parameters
+    ----------
+    settings : AppSettings
+        Loaded application settings; see :func:`build_services`.
+    llm : LLMPort | None, optional
+        Pre-built LLM port; see :func:`build_services`.
+    judge_llm : LLMPort | None, optional
+        Pre-built judge LLM port; see :func:`build_services`.
+    embedder : EmbeddingPort | None, optional
+        Pre-built embedder; see :func:`build_services`.
+
+    Returns
+    -------
+    Orchestrator
+        A fully wired orchestrator ready for ``analyze`` /
+        ``analyze_hierarchical`` calls.
+    """
+    return build_services(
+        settings, llm=llm, judge_llm=judge_llm, embedder=embedder
+    ).orchestrator

--- a/src/qfa/api/dependencies.py
+++ b/src/qfa/api/dependencies.py
@@ -14,6 +14,7 @@ from qfa.domain.usage_models import CallContext, Operation
 from qfa.services.auth_orchestrator import AuthOrchestrator
 from qfa.services.call_context import call_scope
 from qfa.services.orchestrator import Orchestrator
+from qfa.services.sensitivity import SensitivityService
 
 
 def get_orchestrator(request: Request) -> Orchestrator:
@@ -30,6 +31,26 @@ def get_orchestrator(request: Request) -> Orchestrator:
         The orchestrator service instance.
     """
     return request.app.state.orchestrator
+
+
+def get_sensitivity_service(request: Request) -> SensitivityService:
+    """Return the sensitivity-detection service from app state.
+
+    One provider per use-case service (ADR-017): the detect-sensitive
+    handler depends on this service alone, not on the type that reaches
+    every use case.
+
+    Parameters
+    ----------
+    request : Request
+        The incoming HTTP request.
+
+    Returns
+    -------
+    SensitivityService
+        The sensitivity-detection service instance.
+    """
+    return request.app.state.sensitivity_service
 
 
 def get_auth_orchestrator(request: Request) -> AuthOrchestrator:

--- a/src/qfa/api/routes.py
+++ b/src/qfa/api/routes.py
@@ -11,6 +11,7 @@ from qfa.api.dependencies import (
     authenticate_request,
     call_scope_for,
     get_orchestrator,
+    get_sensitivity_service,
 )
 from qfa.api.schemas import (
     ApiAnalyzeBulkResponse,
@@ -48,6 +49,7 @@ from qfa.services.orchestrator import (
     NO_CODING_EMPTY_CONTENT_EXPLANATION,
     Orchestrator,
 )
+from qfa.services.sensitivity import SensitivityService
 
 logger = logging.getLogger(__name__)
 
@@ -487,7 +489,7 @@ async def detect_sensitive(
     body: ApiDetectSensitiveRequest,
     request: Request,
     tenant: TenantApiKey = Depends(authenticate_request),
-    orchestrator: Orchestrator = Depends(get_orchestrator),
+    sensitivity_service: SensitivityService = Depends(get_sensitivity_service),
     _scope: CallContext = Depends(call_scope_for(Operation.DETECT_SENSITIVE)),
 ) -> ApiDetectSensitiveResponse:
     """Detect sensitive content in feedback items.
@@ -504,8 +506,8 @@ async def detect_sensitive(
         The incoming HTTP request.
     tenant : TenantApiKey
         The authenticated tenant, injected via dependency.
-    orchestrator : Orchestrator
-        The orchestrator service, injected via dependency.
+    sensitivity_service : SensitivityService
+        The sensitivity-detection service, injected via dependency.
 
     Returns
     -------
@@ -524,7 +526,7 @@ async def detect_sensitive(
             sensitivity_types=[],
         )
 
-    result = await orchestrator.detect_sensitive_content(
+    result = await sensitivity_service.detect_sensitive_content(
         SensitivityAnalysisRequestModel(
             feedback_record=FeedbackRecordModel(
                 id=body.feedback_record.id,

--- a/src/qfa/services/llm_call_executor.py
+++ b/src/qfa/services/llm_call_executor.py
@@ -1,10 +1,11 @@
 """Shared LLM-call scaffolding for the application services.
 
 Every use case in :mod:`qfa.services` wraps its LLM calls in the same
-four concerns: redact PII before the call, derive a per-call timeout from
-the request deadline, guard the token budget, and bound concurrent calls
-with a semaphore. :class:`LLMCallExecutor` owns those four and nothing
-else, so a use-case service can be read without them.
+four concerns: redact PII before the call (and restore it afterwards),
+derive a per-call timeout from the request deadline, guard the token
+budget, and bound concurrent calls with a semaphore.
+:class:`LLMCallExecutor` owns those four and nothing else, so a use-case
+service can be read without them.
 
 Per ADR-017 this is a plain concrete class, deliberately **not** a
 Protocol and **not** a base class:
@@ -23,6 +24,7 @@ Tests construct the *real* executor over the existing ``FakeLLMPort`` /
 """
 
 import asyncio
+import json
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -34,6 +36,20 @@ from qfa.settings import LLM_RETRY_BUDGET_MULTIPLIER, OrchestratorSettings
 
 #: Minimum time (seconds) required for an LLM attempt to be viable.
 _MINIMUM_ATTEMPT_WINDOW = 10.0
+
+
+def _json_escape_mapping(mapping: dict[str, str]) -> dict[str, str]:
+    """Escape mapping values for safe substitution into a JSON string.
+
+    ``AnonymizationPort.deanonymize`` does a raw substring replace, so
+    restoring a PII value that contains a quote, backslash, or control
+    character (e.g. a newline in an address) directly into an
+    already-serialized JSON string corrupts it. Escaping each value the
+    way ``json.dumps`` would keeps the result valid JSON.
+    """
+    return {
+        placeholder: json.dumps(value)[1:-1] for placeholder, value in mapping.items()
+    }
 
 
 @dataclass
@@ -109,6 +125,18 @@ class LLMCallExecutor:
             new_records.append(record.model_copy(update={"content": redacted}))
         return tuple(new_records), merged
 
+    def anonymize_text(self, text: str) -> tuple[str, dict[str, str]]:
+        """Redact PII from one assembled message, returning text + mapping.
+
+        The single-record use cases anonymise the *assembled* user message
+        rather than each record's content, because the envelope they send is
+        built before the call; :meth:`anonymize_records` is the batch
+        equivalent for the paths that chunk records first. Pair this with
+        :meth:`deanonymize_json` to restore the redacted values in the
+        model's response.
+        """
+        return self._anonymizer.anonymize(text)
+
     async def bounded_complete(
         self,
         semaphore: asyncio.Semaphore,
@@ -122,6 +150,9 @@ class LLMCallExecutor:
         timing: SlotTiming | None = None,
     ) -> LLMResponse[T_Response]:
         """Run one LLM completion, bounded by ``semaphore`` and the deadline.
+
+        This is :meth:`complete` run under ``semaphore``, with the queue-wait
+        measured around the acquire.
 
         ``semaphore`` caps how many completions run at once across the whole
         hierarchical pipeline (map, leaf judge, reduce), so concurrency stays
@@ -144,22 +175,22 @@ class LLMCallExecutor:
         them apart rather than reporting one combined number that hides how long
         the call sat waiting for a slot.
         """
-        client = llm if llm is not None else self._llm
         queue_start = time.perf_counter()
         async with semaphore:
             acquired_at = time.perf_counter()
             if timing is not None:
                 timing.queued_seconds = acquired_at - queue_start
-            # Compute the timeout only now: queue-wait already elapsed, so the
-            # per-call window reflects the budget that actually remains.
-            timeout = self.check_deadline_and_get_timeout(deadline)
             try:
-                return await client.complete(
+                # Delegating here means the timeout is derived only now:
+                # queue-wait already elapsed, so the per-call window reflects
+                # the budget that actually remains.
+                return await self.complete(
+                    llm=llm,
                     system_message=system_message,
                     user_message=user_message,
                     tenant_id=tenant_id,
                     response_model=response_model,
-                    timeout=timeout,
+                    deadline=deadline,
                 )
             finally:
                 if timing is not None:
@@ -214,3 +245,48 @@ class LLMCallExecutor:
                 estimated_tokens=estimated_tokens,
                 limit=self._max_total_tokens,
             )
+
+    async def complete(
+        self,
+        *,
+        llm: LLMPort | None = None,
+        system_message: str,
+        user_message: str,
+        tenant_id: str,
+        response_model: type[T_Response],
+        deadline: datetime,
+    ) -> LLMResponse[T_Response]:
+        """Run one LLM completion bounded by the deadline.
+
+        The per-call timeout is derived from ``deadline`` immediately before
+        the call, so a completion issued late in a request still honours the
+        remaining budget (and raises ``AnalysisTimeoutError`` rather than
+        issuing a call that cannot finish in time).
+
+        Use this for the single-call use cases. The hierarchical pipeline
+        uses :meth:`bounded_complete`, which adds the concurrency semaphore
+        and the queue-wait timing on top of this method.
+
+        ``llm`` overrides the connection for this one call — see
+        :meth:`bounded_complete` for why that override exists; ``None`` uses
+        the executor's own client.
+        """
+        timeout = self.check_deadline_and_get_timeout(deadline)
+        client = llm if llm is not None else self._llm
+        return await client.complete(
+            system_message=system_message,
+            user_message=user_message,
+            tenant_id=tenant_id,
+            response_model=response_model,
+            timeout=timeout,
+        )
+
+    def deanonymize_json(self, payload: str, mapping: dict[str, str]) -> str:
+        """Restore redacted values inside a serialized JSON ``payload``.
+
+        The counterpart to :meth:`anonymize_text` for structured responses:
+        the mapping's values are escaped the way ``json.dumps`` would before
+        substitution, so PII containing a quote or a newline cannot corrupt
+        the JSON the caller is about to re-validate.
+        """
+        return self._anonymizer.deanonymize(payload, _json_escape_mapping(mapping))

--- a/src/qfa/services/orchestrator.py
+++ b/src/qfa/services/orchestrator.py
@@ -11,7 +11,6 @@ class (ADR-017).
 """
 
 import asyncio
-import json
 import logging
 import re
 from dataclasses import dataclass
@@ -40,15 +39,11 @@ from qfa.domain.models import (
     CodingNode,
     FeedbackRecordModel,
     FeedbackRecordSummaryModel,
-    SensitivityAnalysisRequestModel,
-    SensitivityAnalysisResultModel,
-    SensitivityAnalysisResultModelList,
     SingleSummaryRequestModel,
     SummaryRequestModel,
     SummaryResultModel,
 )
 from qfa.domain.ports import AnonymizationPort, EmbeddingPort, LLMPort
-from qfa.domain.sensitivity_types import SENSITIVITY_TYPE_DESCRIPTIONS
 from qfa.services.clustering import cluster_records
 from qfa.services.coding_classifier import (
     JudgeResponse,
@@ -82,11 +77,6 @@ from qfa.utils import timed
 
 logger = logging.getLogger(__name__)
 
-_SENSITIVITY_TYPE_GUIDANCE = "\n".join(
-    f"- {sensitivity_type.value}: {description}"
-    for sensitivity_type, description in SENSITIVITY_TYPE_DESCRIPTIONS.items()
-)
-
 _DEFAULT_SUMMARIZATION_PROMPT = (
     "Summarize the feedback item as concise bullet points.\n"
     "Strict Constraint: The summary must be extremely concise, using no more than 3-5 brief bullet points.\n"
@@ -108,20 +98,6 @@ _DEFAULT_AGGREGATE_SUMMARIZATION_PROMPT = (
     "Do not include markdown code fences.\n"
     "Do not end with a question, an offer of further help, or an invitation for follow-up input.\n"
     "Use the same language as the input feedback records unless a target language is specified."
-)
-
-_DEFAULT_SENSITIVITY_DETECTION_PROMPT = (
-    "Analyze each feedback record and detect whether it contains sensitive content.\n"
-    "Classify sensitivity using only the SensitivityType enum values from the response schema.\n"
-    "For each record, include a concise natural-language explanation for the classification.\n"
-    f"SensitivityType guidance:\n{_SENSITIVITY_TYPE_GUIDANCE}\n"
-    "Return one result per input record with the matching feedback_record_id.\n"
-    "If no sensitive content is present, return an empty sensitivity_types tuple for that record.\n"
-    "Do not include markdown code fences.\n"
-    "Note that anonymization might have taken place (e.g. ``<PERSON_0>``, ``<LOCATION_1>``). \n"
-    "Please act as if these were not anonymized. For example, if you see ``<PERSON_0>``"
-    " treat it as if it said 'John Doe' and classify sensitivity accordingly. \n"
-    "Please note that we prefer false positives over false negatives in this classification."
 )
 
 _JUDGE_PROMPT = """
@@ -200,20 +176,6 @@ def _parse_judge_quality_score(raw: str) -> float:
 def _build_judge_system_message(source_text: str, summary: str) -> str:
     """Fill the judge prompt with the provided source text and summary."""
     return _JUDGE_PROMPT.format(source_text=source_text, summary=summary)
-
-
-def _json_escape_mapping(mapping: dict[str, str]) -> dict[str, str]:
-    """Escape mapping values for safe substitution into a JSON string.
-
-    ``AnonymizationPort.deanonymize`` does a raw substring replace, so
-    restoring a PII value that contains a quote, backslash, or control
-    character (e.g. a newline in an address) directly into an
-    already-serialized JSON string corrupts it. Escaping each value the
-    way ``json.dumps`` would keeps the result valid JSON.
-    """
-    return {
-        placeholder: json.dumps(value)[1:-1] for placeholder, value in mapping.items()
-    }
 
 
 def _hyperlink_form_references(
@@ -1234,8 +1196,8 @@ class Orchestrator:
         response.structured.quality_score = quality_score
 
         return_model_as_string = response.structured.model_dump_json()
-        unanonymized_return_model_as_string = self._anonymizer.deanonymize(
-            return_model_as_string, _json_escape_mapping(anonymization_mapping)
+        unanonymized_return_model_as_string = self._executor.deanonymize_json(
+            return_model_as_string, anonymization_mapping
         )
         result = AggregateSummaryResultModel.model_validate_json(
             unanonymized_return_model_as_string
@@ -1311,8 +1273,8 @@ class Orchestrator:
         quality_score = _parse_judge_quality_score(judge_response.structured)
 
         return_model_as_string = llm_completion.structured.model_dump_json()
-        unanonymized_return_model_as_string = self._anonymizer.deanonymize(
-            return_model_as_string, _json_escape_mapping(anonymization_mapping)
+        unanonymized_return_model_as_string = self._executor.deanonymize_json(
+            return_model_as_string, anonymization_mapping
         )
         result = SummaryResultModel.model_validate_json(
             unanonymized_return_model_as_string
@@ -1426,56 +1388,6 @@ class Orchestrator:
         ]
 
         return CodingAssignmentResultModel(coded_feedback_records=tuple(coded))
-
-    async def detect_sensitive_content(
-        self,
-        request: SensitivityAnalysisRequestModel,
-        deadline: datetime,
-    ) -> SensitivityAnalysisResultModel:
-        """Detect sensitive content in a single feedback record.
-
-        Parameters
-        ----------
-        request : SensitivityAnalysisRequestModel
-            The sensitivity analysis request containing a single feedback record.
-
-        Returns
-        -------
-        SensitivityAnalysisResultModel
-            The sensitivity analysis result for the feedback record.
-        """
-        timeout = self._executor.check_deadline_and_get_timeout(deadline)
-        system_message = _DEFAULT_SENSITIVITY_DETECTION_PROMPT
-        user_message = build_feedback_record_envelope(
-            request.feedback_record, include_metadata=True, include_id=True
-        )
-
-        anonymized_user_message, anonymization_mapping = self._anonymizer.anonymize(
-            user_message
-        )
-
-        response = await self._llm.complete(
-            system_message=system_message,
-            user_message=anonymized_user_message,
-            tenant_id=request.tenant_id,
-            response_model=SensitivityAnalysisResultModelList,
-            timeout=timeout,
-        )
-
-        return_model_as_string = response.structured.model_dump_json()
-        unanonymized_return_model_as_string = self._anonymizer.deanonymize(
-            return_model_as_string, _json_escape_mapping(anonymization_mapping)
-        )
-        structured = SensitivityAnalysisResultModelList.model_validate_json(
-            unanonymized_return_model_as_string
-        )
-
-        raw = structured.results[0] if structured.results else None
-        return SensitivityAnalysisResultModel(
-            feedback_record_id=request.feedback_record.id,
-            sensitivity_types=raw.sensitivity_types if raw else (),
-            explanation=raw.explanation if raw else "No sensitive content detected.",
-        )
 
     def _check_coding_deadline(self, deadline: datetime) -> None:
         """Raise when the coding deadline is exceeded."""

--- a/src/qfa/services/sensitivity.py
+++ b/src/qfa/services/sensitivity.py
@@ -1,0 +1,113 @@
+"""Sensitivity-detection use case.
+
+One LLM call per feedback record, classifying it against the
+:class:`~qfa.domain.sensitivity_types.SensitivityType` vocabulary. This is
+the smallest of the use cases extracted from ``Orchestrator`` by epic #112:
+no embedder, no judge connection, no chunking — which is why its
+constructor names exactly one dependency.
+
+Per ADR-017 this class has **no base class**: the LLM-call scaffolding it
+shares with the other use cases (anonymise, deadline→timeout, the call
+itself, deanonymise) is the injected
+:class:`~qfa.services.llm_call_executor.LLMCallExecutor` it delegates to,
+not a superclass it inherits from.
+"""
+
+from datetime import datetime
+
+from qfa.domain.models import (
+    SensitivityAnalysisRequestModel,
+    SensitivityAnalysisResultModel,
+    SensitivityAnalysisResultModelList,
+)
+from qfa.domain.sensitivity_types import SENSITIVITY_TYPE_DESCRIPTIONS
+from qfa.services.llm_call_executor import LLMCallExecutor
+from qfa.services.prompts import build_feedback_record_envelope
+
+_SENSITIVITY_TYPE_GUIDANCE = "\n".join(
+    f"- {sensitivity_type.value}: {description}"
+    for sensitivity_type, description in SENSITIVITY_TYPE_DESCRIPTIONS.items()
+)
+
+_DEFAULT_SENSITIVITY_DETECTION_PROMPT = (
+    "Analyze each feedback record and detect whether it contains sensitive content.\n"
+    "Classify sensitivity using only the SensitivityType enum values from the response schema.\n"
+    "For each record, include a concise natural-language explanation for the classification.\n"
+    f"SensitivityType guidance:\n{_SENSITIVITY_TYPE_GUIDANCE}\n"
+    "Return one result per input record with the matching feedback_record_id.\n"
+    "If no sensitive content is present, return an empty sensitivity_types tuple for that record.\n"
+    "Do not include markdown code fences.\n"
+    "Note that anonymization might have taken place (e.g. ``<PERSON_0>``, ``<LOCATION_1>``). \n"
+    "Please act as if these were not anonymized. For example, if you see ``<PERSON_0>``"
+    " treat it as if it said 'John Doe' and classify sensitivity accordingly. \n"
+    "Please note that we prefer false positives over false negatives in this classification."
+)
+
+
+class SensitivityService:
+    """Detect sensitive content in a single feedback record.
+
+    Parameters
+    ----------
+    executor : LLMCallExecutor
+        The shared LLM-call scaffolding this use case delegates to:
+        anonymisation of the outgoing message, the deadline-bounded call
+        itself, and restoration of the redacted values in the response. The
+        composition root (:func:`qfa.api.composition.build_services`) hands
+        over the same instance the other services use.
+    """
+
+    def __init__(self, executor: LLMCallExecutor) -> None:
+        self._executor = executor
+
+    async def detect_sensitive_content(
+        self,
+        request: SensitivityAnalysisRequestModel,
+        deadline: datetime,
+    ) -> SensitivityAnalysisResultModel:
+        """Detect sensitive content in a single feedback record.
+
+        Parameters
+        ----------
+        request : SensitivityAnalysisRequestModel
+            The sensitivity analysis request containing a single feedback record.
+        deadline : datetime
+            The wall-clock deadline for the whole request; the LLM call is
+            timed out against whatever remains of it.
+
+        Returns
+        -------
+        SensitivityAnalysisResultModel
+            The sensitivity analysis result for the feedback record.
+        """
+        system_message = _DEFAULT_SENSITIVITY_DETECTION_PROMPT
+        user_message = build_feedback_record_envelope(
+            request.feedback_record, include_metadata=True, include_id=True
+        )
+
+        anonymized_user_message, anonymization_mapping = self._executor.anonymize_text(
+            user_message
+        )
+
+        response = await self._executor.complete(
+            system_message=system_message,
+            user_message=anonymized_user_message,
+            tenant_id=request.tenant_id,
+            response_model=SensitivityAnalysisResultModelList,
+            deadline=deadline,
+        )
+
+        return_model_as_string = response.structured.model_dump_json()
+        unanonymized_return_model_as_string = self._executor.deanonymize_json(
+            return_model_as_string, anonymization_mapping
+        )
+        structured = SensitivityAnalysisResultModelList.model_validate_json(
+            unanonymized_return_model_as_string
+        )
+
+        raw = structured.results[0] if structured.results else None
+        return SensitivityAnalysisResultModel(
+            feedback_record_id=request.feedback_record.id,
+            sensitivity_types=raw.sensitivity_types if raw else (),
+            explanation=raw.explanation if raw else "No sensitive content detected.",
+        )

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -330,6 +330,10 @@ def test_app(fake_orchestrator, fake_auth_orchestrator):
     register_exception_handlers(app)
 
     app.state.orchestrator = fake_orchestrator
+    # The extracted use-case services get their own app.state slot (ADR-017).
+    # FakeOrchestrator still implements every use case, so one fake backs both
+    # slots until the remaining extractions land.
+    app.state.sensitivity_service = fake_orchestrator
     app.state.auth_orchestrator = fake_auth_orchestrator
     app.state.usage_repo = FakeUsageRepository()
 

--- a/tests/api/test_composition.py
+++ b/tests/api/test_composition.py
@@ -10,8 +10,13 @@ from pydantic import SecretStr
 
 from qfa.adapters.llm_client import LiteLLMClient
 from qfa.adapters.presidio_anonymizer import PresidioAnonymizer
-from qfa.api.composition import build_orchestrator, resolve_judge_llm_settings
+from qfa.api.composition import (
+    build_orchestrator,
+    build_services,
+    resolve_judge_llm_settings,
+)
 from qfa.services.orchestrator import Orchestrator
+from qfa.services.sensitivity import SensitivityService
 from qfa.settings import AppSettings, JudgeLLMSettings, LLMSettings
 
 JUDGE_ENV_VARS = (
@@ -370,3 +375,35 @@ class TestBuildOrchestrator:
 
         assert orchestrator._llm_timeout_seconds == expected_timeout
         assert orchestrator._max_total_tokens == expected_max_tokens
+
+
+class TestBuildServices:
+    """The factory builds every service over one shared executor."""
+
+    def test_builds_each_service_in_the_graph(self, auth_env: None) -> None:
+        services = build_services(AppSettings(), llm=_StubLLM())
+
+        assert isinstance(services.orchestrator, Orchestrator)
+        assert isinstance(services.sensitivity, SensitivityService)
+
+    def test_services_share_one_llm_call_executor(self, auth_env: None) -> None:
+        """Identity, not equality: the executor is configured once per process.
+
+        A second executor would mean a second copy of the per-call timeout,
+        the token ceiling and the anonymiser, which could then drift apart
+        between endpoints without any test noticing.
+        """
+        services = build_services(AppSettings(), llm=_StubLLM())
+
+        assert services.sensitivity._executor is services.orchestrator._executor
+
+    def test_build_orchestrator_returns_the_graphs_orchestrator(
+        self, auth_env: None
+    ) -> None:
+        """The narrow wrapper is the same construction, minus the other services."""
+        stub_llm = _StubLLM()
+
+        orchestrator = build_orchestrator(AppSettings(), llm=stub_llm)
+
+        assert isinstance(orchestrator, Orchestrator)
+        assert orchestrator._llm is stub_llm

--- a/tests/api/test_lifespan.py
+++ b/tests/api/test_lifespan.py
@@ -1,7 +1,7 @@
 """Tests for the FastAPI lifespan's LLM wiring.
 
 Why: the lifespan is the *infrastructure* half of the composition root, and it
-owns the one thing ``build_orchestrator`` deliberately does not — wrapping each
+owns the one thing ``build_services`` deliberately does not — wrapping each
 LLM client in :class:`TrackingLLMAdapter` so usage and cost are recorded. A
 judge client that reached the orchestrator unwrapped would work perfectly and
 silently bill nothing, which no functional test would catch.
@@ -22,6 +22,7 @@ from qfa.adapters.tracking_llm import TrackingLLMAdapter
 from qfa.api.app import create_app
 from qfa.domain.models import LLMResponse
 from qfa.domain.ports import LLMPort
+from qfa.services.sensitivity import SensitivityService
 from qfa.settings import LLMSettings
 
 JUDGE_ENV_VARS = (
@@ -162,3 +163,21 @@ async def test_judge_model_alone_is_a_valid_startup_configuration(
         assert judge_settings.model == "azure/some-other-deployment"
         assert judge_settings.api_key.get_secret_value() == "sk-test-lifespan"
         assert judge_settings.api_base == "https://res.openai.azure.com/"
+
+
+@pytest.mark.asyncio
+async def test_every_service_is_published_on_app_state(app_env: None):
+    """Each extracted use-case service gets its own ``app.state`` slot.
+
+    The route providers read one slot each, so a service the lifespan forgets
+    to publish is a 500 on that endpoint alone — invisible to every other
+    test in this module.
+    """
+    app = create_app(llm_factory=_RecordingFakeLLM)
+
+    async with app.router.lifespan_context(app):
+        assert isinstance(app.state.sensitivity_service, SensitivityService)
+        # Built from the same graph, so the tracked LLM reaches it too.
+        assert (
+            app.state.sensitivity_service._executor is app.state.orchestrator._executor
+        )

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -866,7 +866,7 @@ class TestErrorMapping:
 
     @pytest.mark.asyncio
     async def test_detect_sensitive_502_analysis_error(self, test_app):
-        test_app.state.orchestrator = FakeOrchestrator(
+        test_app.state.sensitivity_service = FakeOrchestrator(
             error=AnalysisError("LLM failure")
         )
         async with _make_client(test_app) as c:

--- a/tests/services/test_llm_call_executor.py
+++ b/tests/services/test_llm_call_executor.py
@@ -13,6 +13,7 @@ the existing ``FakeLLMPort`` / ``FakeAnonymizer`` doubles from
 """
 
 import asyncio
+import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -225,6 +226,67 @@ class TestAnonymizeRecords:
 
         assert anonymized is records
         assert mapping == {}
+
+
+class TestAnonymizeTextAndDeanonymizeJson:
+    def test_round_trips_an_assembled_message_through_a_json_response(self):
+        executor = _make_executor(anonymizer=RedactingAnonymizer())
+
+        redacted, mapping = executor.anonymize_text("Jane reported a leak.")
+        restored = executor.deanonymize_json(
+            f'{{"explanation": "{redacted}"}}', mapping
+        )
+
+        assert redacted == "<PERSON_0> reported a leak."
+        assert json.loads(restored) == {"explanation": "Jane reported a leak."}
+
+    def test_restored_values_are_escaped_so_the_payload_stays_valid_json(self):
+        """PII containing a quote must not break the JSON it is restored into.
+
+        ``deanonymize`` is a raw substring replace, so an unescaped value
+        would terminate the string it lands in and the caller's
+        ``model_validate_json`` would fail on valid model output.
+        """
+        executor = _make_executor(anonymizer=RedactingAnonymizer())
+        mapping = {"<PERSON_0>": 'Jane "JJ" Doe\n'}
+
+        restored = executor.deanonymize_json('{"explanation": "<PERSON_0>"}', mapping)
+
+        assert json.loads(restored) == {"explanation": 'Jane "JJ" Doe\n'}
+
+
+class TestComplete:
+    @pytest.mark.asyncio
+    async def test_passes_the_deadline_derived_timeout_to_the_port(self):
+        fake_llm = FakeLLMPort(responses=[_make_response("done")])
+        executor = _make_executor(llm=fake_llm)
+
+        response = await executor.complete(
+            system_message="sys",
+            user_message="user",
+            tenant_id=TENANT_ID,
+            response_model=str,
+            deadline=_future_deadline(),
+        )
+
+        assert response.structured == "done"
+        assert fake_llm.calls[0]["timeout"] == pytest.approx(LLM_TIMEOUT)
+
+    @pytest.mark.asyncio
+    async def test_expired_deadline_raises_before_calling_the_llm(self):
+        fake_llm = FakeLLMPort(responses=[_make_response()])
+        executor = _make_executor(llm=fake_llm)
+
+        with pytest.raises(AnalysisTimeoutError):
+            await executor.complete(
+                system_message="sys",
+                user_message="user",
+                tenant_id=TENANT_ID,
+                response_model=str,
+                deadline=_past_deadline(),
+            )
+
+        assert fake_llm.calls == []
 
 
 class TestBoundedComplete:

--- a/tests/services/test_orchestrator.py
+++ b/tests/services/test_orchestrator.py
@@ -19,15 +19,11 @@ from qfa.domain.models import (
     FeedbackRecordModel,
     FeedbackRecordSummaryModel,
     LLMResponse,
-    SensitivityAnalysisRequestModel,
-    SensitivityAnalysisResultModel,
-    SensitivityAnalysisResultModelList,
     SingleSummaryRequestModel,
     SummaryRequestModel,
     SummaryResultModel,
 )
 from qfa.domain.ports import AnonymizationPort, LLMPort
-from qfa.domain.sensitivity_types import SensitivityType
 from qfa.services.coding_classifier import JudgeResponse
 from qfa.services.orchestrator import (
     NO_CODING_NOTHING_RELEVANT_EXPLANATION,
@@ -144,29 +140,6 @@ def _make_aggregate_request(
         feedback_records=feedback_records,
         tenant_id=tenant_id,
         output_language=output_language,
-    )
-
-
-def _make_sensitivity_request(feedback_record=None, tenant_id=TENANT_ID):
-    if feedback_record is None:
-        feedback_record = _make_feedback_record()
-    return SensitivityAnalysisRequestModel(
-        feedback_record=feedback_record,
-        tenant_id=tenant_id,
-    )
-
-
-def _make_sensitivity_result(item_id="doc-1", sensitivity_types=None):
-    if sensitivity_types is None:
-        sensitivity_types = (SensitivityType.CORRUPTION,)
-    return SensitivityAnalysisResultModelList(
-        results=(
-            SensitivityAnalysisResultModel(
-                feedback_record_id=item_id,
-                sensitivity_types=sensitivity_types,
-                explanation="Contains a corruption allegation.",
-            ),
-        )
     )
 
 
@@ -477,110 +450,6 @@ class TestNonTransientError:
             await orch.summarize_bulk(_make_aggregate_request(), _future_deadline())
 
         assert len(fake_llm.calls) == 2
-
-
-class TestDetectSensitiveContent:
-    @pytest.mark.asyncio
-    async def test_returns_structured_result_from_llm(self, settings):
-        fake_llm = FakeLLMPort(
-            responses=[
-                _make_llm_response(
-                    structured=_make_sensitivity_result(),
-                )
-            ]
-        )
-        orch = Orchestrator(
-            llm=fake_llm,
-            anonymizer=FakeAnonymizer(),
-            settings=settings,
-            llm_timeout_seconds=LLM_TIMEOUT,
-            max_total_tokens=MAX_TOKENS,
-        )
-
-        result = await orch.detect_sensitive_content(
-            _make_sensitivity_request(), _future_deadline()
-        )
-
-        assert result.feedback_record_id == "doc-1"
-        assert result.is_sensitive is True
-        assert fake_llm.calls[0]["response_model"] is SensitivityAnalysisResultModelList
-
-    @pytest.mark.asyncio
-    async def test_tenant_id_in_llm_call(self, settings):
-        fake_llm = FakeLLMPort(
-            responses=[
-                _make_llm_response(structured=_make_sensitivity_result()),
-            ]
-        )
-        orch = Orchestrator(
-            llm=fake_llm,
-            anonymizer=FakeAnonymizer(),
-            settings=settings,
-            llm_timeout_seconds=LLM_TIMEOUT,
-            max_total_tokens=MAX_TOKENS,
-        )
-
-        await orch.detect_sensitive_content(
-            _make_sensitivity_request(tenant_id="special-tenant"),
-            _future_deadline(),
-        )
-
-        assert fake_llm.calls[0]["tenant_id"] == "special-tenant"
-
-    @pytest.mark.asyncio
-    async def test_result_id_is_pinned_to_request_record(self, settings):
-        fake_llm = FakeLLMPort(
-            responses=[
-                _make_llm_response(
-                    structured=SensitivityAnalysisResultModelList(
-                        results=(
-                            SensitivityAnalysisResultModel(
-                                feedback_record_id="wrong-1",
-                                sensitivity_types=(SensitivityType.CORRUPTION,),
-                                explanation="Bribery risk.",
-                            ),
-                        )
-                    ),
-                ),
-            ]
-        )
-        orch = Orchestrator(
-            llm=fake_llm,
-            anonymizer=FakeAnonymizer(),
-            settings=settings,
-            llm_timeout_seconds=LLM_TIMEOUT,
-            max_total_tokens=MAX_TOKENS,
-        )
-
-        result = await orch.detect_sensitive_content(
-            _make_sensitivity_request(
-                feedback_record=_make_feedback_record(doc_id="doc-1")
-            ),
-            _future_deadline(),
-        )
-
-        assert result.feedback_record_id == "doc-1"
-        assert result.sensitivity_types == (SensitivityType.CORRUPTION,)
-
-    @pytest.mark.asyncio
-    async def test_prompt_contains_sensitivity_guidance(self, settings):
-        fake_llm = FakeLLMPort(
-            responses=[_make_llm_response(structured=_make_sensitivity_result())]
-        )
-        orch = Orchestrator(
-            llm=fake_llm,
-            anonymizer=FakeAnonymizer(),
-            settings=settings,
-            llm_timeout_seconds=LLM_TIMEOUT,
-            max_total_tokens=MAX_TOKENS,
-        )
-
-        await orch.detect_sensitive_content(
-            _make_sensitivity_request(), _future_deadline()
-        )
-
-        system_msg = fake_llm.calls[0]["system_message"]
-        assert "CORRUPTION: Apply when feedback alleges bribery" in system_msg
 
 
 class TestTenantIdPassedThrough:

--- a/tests/services/test_sensitivity.py
+++ b/tests/services/test_sensitivity.py
@@ -1,0 +1,177 @@
+"""Tests for :class:`~qfa.services.sensitivity.SensitivityService`.
+
+Moved here from ``test_orchestrator`` when the use case was extracted
+(#263). Per ADR-017 the service is exercised over the **real**
+:class:`~qfa.services.llm_call_executor.LLMCallExecutor`, constructed over
+the existing ``FakeLLMPort`` / ``FakeAnonymizer`` doubles — there is no
+fake executor and no stub of the service itself.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from qfa.domain.models import (
+    FeedbackRecordMetadataModel,
+    FeedbackRecordModel,
+    LLMResponse,
+    SensitivityAnalysisRequestModel,
+    SensitivityAnalysisResultModel,
+    SensitivityAnalysisResultModelList,
+)
+from qfa.domain.sensitivity_types import SensitivityType
+from qfa.services.llm_call_executor import LLMCallExecutor
+from qfa.services.sensitivity import SensitivityService
+from qfa.settings import OrchestratorSettings
+
+# Reuse the doubles the orchestrator suite already ships rather than growing a
+# second, drifting pair (ADR-017).
+from .test_orchestrator import FakeAnonymizer, FakeLLMPort
+
+TENANT_ID = "tenant-42"
+LLM_TIMEOUT = 30.0
+MAX_TOKENS = 10_000
+
+
+@pytest.fixture
+def settings():
+    return OrchestratorSettings()
+
+
+def _make_feedback_record(doc_id="doc-1", content="Some feedback text."):
+    return FeedbackRecordModel(
+        id=doc_id,
+        content=content,
+        metadata=FeedbackRecordMetadataModel.model_validate({}),
+        url_id="",
+    )
+
+
+def _make_llm_response(structured, model="gpt-4", cost=0.001):
+    return LLMResponse(
+        structured=structured,
+        model=model,
+        prompt_tokens=100,
+        completion_tokens=50,
+        cost=cost,
+    )
+
+
+def _make_sensitivity_request(feedback_record=None, tenant_id=TENANT_ID):
+    if feedback_record is None:
+        feedback_record = _make_feedback_record()
+    return SensitivityAnalysisRequestModel(
+        feedback_record=feedback_record,
+        tenant_id=tenant_id,
+    )
+
+
+def _make_sensitivity_result(item_id="doc-1", sensitivity_types=None):
+    if sensitivity_types is None:
+        sensitivity_types = (SensitivityType.CORRUPTION,)
+    return SensitivityAnalysisResultModelList(
+        results=(
+            SensitivityAnalysisResultModel(
+                feedback_record_id=item_id,
+                sensitivity_types=sensitivity_types,
+                explanation="Contains a corruption allegation.",
+            ),
+        )
+    )
+
+
+def _future_deadline(seconds=300):
+    return datetime.now(tz=UTC) + timedelta(seconds=seconds)
+
+
+def _make_service(fake_llm, settings, anonymizer=None):
+    """Build the service over the real executor, as ADR-017 prescribes."""
+    return SensitivityService(
+        executor=LLMCallExecutor(
+            llm=fake_llm,
+            anonymizer=anonymizer or FakeAnonymizer(),
+            settings=settings,
+            llm_timeout_seconds=LLM_TIMEOUT,
+            max_total_tokens=MAX_TOKENS,
+        )
+    )
+
+
+class TestDetectSensitiveContent:
+    @pytest.mark.asyncio
+    async def test_returns_structured_result_from_llm(self, settings):
+        fake_llm = FakeLLMPort(
+            responses=[
+                _make_llm_response(
+                    structured=_make_sensitivity_result(),
+                )
+            ]
+        )
+        service = _make_service(fake_llm, settings)
+
+        result = await service.detect_sensitive_content(
+            _make_sensitivity_request(), _future_deadline()
+        )
+
+        assert result.feedback_record_id == "doc-1"
+        assert result.is_sensitive is True
+        assert fake_llm.calls[0]["response_model"] is SensitivityAnalysisResultModelList
+
+    @pytest.mark.asyncio
+    async def test_tenant_id_in_llm_call(self, settings):
+        fake_llm = FakeLLMPort(
+            responses=[
+                _make_llm_response(structured=_make_sensitivity_result()),
+            ]
+        )
+        service = _make_service(fake_llm, settings)
+
+        await service.detect_sensitive_content(
+            _make_sensitivity_request(tenant_id="special-tenant"),
+            _future_deadline(),
+        )
+
+        assert fake_llm.calls[0]["tenant_id"] == "special-tenant"
+
+    @pytest.mark.asyncio
+    async def test_result_id_is_pinned_to_request_record(self, settings):
+        fake_llm = FakeLLMPort(
+            responses=[
+                _make_llm_response(
+                    structured=SensitivityAnalysisResultModelList(
+                        results=(
+                            SensitivityAnalysisResultModel(
+                                feedback_record_id="wrong-1",
+                                sensitivity_types=(SensitivityType.CORRUPTION,),
+                                explanation="Bribery risk.",
+                            ),
+                        )
+                    ),
+                ),
+            ]
+        )
+        service = _make_service(fake_llm, settings)
+
+        result = await service.detect_sensitive_content(
+            _make_sensitivity_request(
+                feedback_record=_make_feedback_record(doc_id="doc-1")
+            ),
+            _future_deadline(),
+        )
+
+        assert result.feedback_record_id == "doc-1"
+        assert result.sensitivity_types == (SensitivityType.CORRUPTION,)
+
+    @pytest.mark.asyncio
+    async def test_prompt_contains_sensitivity_guidance(self, settings):
+        fake_llm = FakeLLMPort(
+            responses=[_make_llm_response(structured=_make_sensitivity_result())]
+        )
+        service = _make_service(fake_llm, settings)
+
+        await service.detect_sensitive_content(
+            _make_sensitivity_request(), _future_deadline()
+        )
+
+        system_msg = fake_llm.calls[0]["system_message"]
+        assert "CORRUPTION: Apply when feedback alleges bribery" in system_msg


### PR DESCRIPTION
Committed, tree clean.

---

## PR-ready summary — `refactor(services): extract SensitivityService from Orchestrator` (closes #263)

### What changed

**New service** — `src/qfa/services/sensitivity.py` defines `SensitivityService`, no base class, one constructor dependency (`LLMCallExecutor`). `detect_sensitive_content` plus its two prompt constants moved here and are **deleted** from `Orchestrator`, which drops from six public use cases to five.

**Executor grew three methods** (`src/qfa/services/llm_call_executor.py`) — the friction this "smallest extraction first" was meant to surface. The use case needs string-level PII handling and a single non-semaphore call, none of which #262 exposed:
- `anonymize_text(text)` — redact one assembled message (batch sibling of `anonymize_records`).
- `deanonymize_json(payload, mapping)` — the restore round trip, now owning the JSON escaping that was `Orchestrator._json_escape_mapping`. That private helper is deleted and the orchestrator's two remaining call sites (`summarize`, `summarize_bulk`) delegate here, so the escaping lives in one place.
- `complete(...)` — one deadline-bounded completion. `bounded_complete` is now literally "`complete` under a semaphore, with queue-wait timing" and delegates to it.

All three sit inside the remit ADR-017 decision 1 assigns the executor ("retry, deadline enforcement, token-limit check, anonymize/deanonymize"), and the next three extractions hit the identical shape at `summarize` / `summarize_bulk` / `assign_codes`.

**Wiring** — `get_sensitivity_service` added to `qfa/api/dependencies.py`; the `/v1/detect-sensitive` handler annotates against `SensitivityService` and no longer takes `Orchestrator`. `composition.build_services()` returns a frozen `ServiceGraph(orchestrator, sensitivity)` built over **one** shared `LLMCallExecutor`; `build_orchestrator` survives as a thin wrapper so scripts, notebooks and existing tests are untouched. The lifespan publishes `app.state.sensitivity_service`.

**Tests** — 4 tests moved verbatim in intent to `tests/services/test_sensitivity.py`, constructing the real executor over `FakeLLMPort`/`FakeAnonymizer`; no assertion weakened or dropped. Added: executor coverage for `complete` (deadline-derived timeout, expired deadline raises before the call) and the anonymise/deanonymise round trip including the quote-and-newline escaping case; composition coverage that the services share one executor instance; a lifespan test that every service reaches `app.state`.

**Docs** — `docs/architecture/03-components.md` (use-case table, new extracted-services table, expanded executor table, composition-root prose) and a note in `docs/development/implementing-a-new-endpoint.md` pointing new endpoints at the service+provider pattern instead of `get_orchestrator`.

### Verification
`make lint` clean (ruff, ty, all 3 import-linter contracts kept) · `make test` 621 passed · strict `make docs` (`-W`) builds.

### Impact / risk
No API change: response shape, status codes and error payloads for `/v1/detect-sensitive` are identical, and the endpoint's assertions are untouched. Risk is concentrated in two places rather than the new service: (1) `bounded_complete` now derives its timeout inside `complete` — same position relative to the semaphore acquire, but on the deadline-expired path `SlotTiming.call_seconds` is now populated instead of left at `0.0` (debug logging only, no test depended on it); (2) two `summarize` paths switched to `executor.deanonymize_json`, same escaping, same behaviour.

### One deviation from the acceptance criteria
The AC asked that existing API tests pass **unmodified**. One line of *fixture wiring* had to change: `tests/api/test_routes.py::test_detect_sensitive_502_analysis_error` reassigns `test_app.state.orchestrator` to inject its error fake, and the route no longer reads that slot — it now assigns `state.sensitivity_service`. Assertions are unchanged. `tests/api/conftest.py` points both slots at the same `FakeOrchestrator`, so every other sensitivity test (including the metadata-forwarding one that asserts on `state.orchestrator`) is byte-identical.

`spec/issue-263.md` checkboxes were left unticked — the spec is the signed-off record, not a working file.

Fixes #263

~Written by Claude, run via the agentic engineering loop