### PR TITLE
docs+test: address review findings on #279 (CodingService extraction)

### DIFF
--- a/docs/architecture/01-architecture-style.md
+++ b/docs/architecture/01-architecture-style.md
@@ -35,7 +35,7 @@ Allowed import directions (enforced by `import-linter`):
 
 ## What's *not* hexagonal here
 
-Hexagonal tells us "services depend only on ports" — it doesn't say "one orchestrator class with N methods" versus "N orchestrator classes." [ADR-011](../adr/011-drop-orchestrator-port.md) started from one {py:class}`~qfa.services.orchestrator.Orchestrator` holding every operation and anticipated extracting individual use cases once one grew enough to warrant it; [ADR-017](../adr/017-orchestrator-composition-only.md) takes that escape valve and splits the class into one service per use case, sharing behaviour by composition rather than a base class. {py:class}`~qfa.services.coding.CodingService` (assign-codes) is extracted; `analyze`, `summarize` and `detect_sensitive_content` still sit on `Orchestrator` while the epic runs.
+Hexagonal tells us "services depend only on ports" — it doesn't say "one orchestrator class with N methods" versus "N orchestrator classes." [ADR-011](../adr/011-drop-orchestrator-port.md) started from one {py:class}`~qfa.services.orchestrator.Orchestrator` holding every operation and anticipated extracting individual use cases once one grew enough to warrant it; [ADR-017](../adr/017-orchestrator-composition-only.md) takes that escape valve and splits the class into one service per use case, sharing behaviour by composition rather than a base class. {py:class}`~qfa.services.sensitivity.SensitivityService` (detect-sensitive) and {py:class}`~qfa.services.coding.CodingService` (assign-codes) are extracted; `analyze` and `summarize` still sit on `Orchestrator` while the epic runs.
 
 ## Further reading
 

--- a/docs/architecture/03-components.md
+++ b/docs/architecture/03-components.md
@@ -101,34 +101,30 @@ the rationale, and flow/sequence diagrams.
 
 Each use case is one async method backing one HTTP endpoint:
 
-| Service | Method | Endpoint | What it does |
-|---|---|---|---|
-| {py:class}`~qfa.services.orchestrator.Orchestrator` | `analyze` | `POST /v1/analyze` (`mode=single_pass`) | One LLM call. Free-text summary of themes across submitted records. |
-| {py:class}`~qfa.services.orchestrator.Orchestrator` | `analyze_hierarchical` | `POST /v1/analyze` (`mode=hierarchical`) | Embed -> cluster -> map -> reduce pipeline. Returns additional `confidence` and `coding_trends` fields. |
-| {py:class}`~qfa.services.orchestrator.Orchestrator` | `summarize` | `POST /v1/summarize` | One LLM call. Per-record summaries with a self-evaluated quality score. |
-| {py:class}`~qfa.services.coding.CodingService` | `assign_codes` | `POST /v1/assign-codes` | Multiple LLM calls per record: pick + judge at each level of a hierarchical coding framework. |
-| {py:class}`~qfa.services.sensitivity.SensitivityService` | `detect_sensitive_content` | `POST /v1/detect-sensitive` | One LLM call per record. Detects sensitive content and categorizes sensitivity types. |
+| Service | Method | Endpoint | Provider | What it does |
+|---|---|---|---|---|
+| {py:class}`~qfa.services.orchestrator.Orchestrator` | `analyze` | `POST /v1/analyze` (`mode=single_pass`) | `get_orchestrator` | One LLM call. Free-text summary of themes across submitted records. |
+| {py:class}`~qfa.services.orchestrator.Orchestrator` | `analyze_hierarchical` | `POST /v1/analyze` (`mode=hierarchical`) | `get_orchestrator` | Embed -> cluster -> map -> reduce pipeline. Returns additional `confidence` and `coding_trends` fields. |
+| {py:class}`~qfa.services.orchestrator.Orchestrator` | `summarize` | `POST /v1/summarize` | `get_orchestrator` | One LLM call. Per-record summaries with a self-evaluated quality score. |
+| {py:class}`~qfa.services.coding.CodingService` | `assign_codes` | `POST /v1/assign-codes` | `get_coding_service` | One LLM call picks the best-fitting code path(s) directly from the whole flattened coding framework, then a separate judge call per level scores each selected path, root to leaf. |
+| {py:class}`~qfa.services.sensitivity.SensitivityService` | `detect_sensitive_content` | `POST /v1/detect-sensitive` | `get_sensitivity_service` | One LLM call per record. Detects sensitive content and categorizes sensitivity types. |
 
 `/v1/summarize`, `/v1/assign-codes`, and `/v1/detect-sensitive` are non-bulk endpoints with per-record outputs. `/v1/analyze` is the bulk endpoint and returns one aggregate result per request (for both `mode=single_pass` and `mode=hierarchical`).
 
-Epic #112 is moving each use case out of the one `Orchestrator` class and into its own service, per [ADR-017](../adr/017-orchestrator-composition-only.md). {py:class}`~qfa.services.sensitivity.SensitivityService` and {py:class}`~qfa.services.coding.CodingService` are the ones extracted so far: each holds its use case's logic, takes the LLM connection, the anonymiser and the shared executor as constructor dependencies, and has **no base class**. The rows still pointing at `Orchestrator` follow in later PRs; the class disappears with #267.
+Epic #112 is moving each use case out of the one `Orchestrator` class and into
+its own service, per [ADR-017](../adr/017-orchestrator-composition-only.md).
+{py:class}`~qfa.services.sensitivity.SensitivityService` and
+{py:class}`~qfa.services.coding.CodingService` are the ones extracted so far.
+Each extracted service is a plain class in `qfa.services` that owns exactly one
+use case, takes the LLM connection, the anonymiser and the shared
+{py:class}`~qfa.services.llm_call_executor.LLMCallExecutor` as constructor
+dependencies, and has **no base class**. The rows still pointing at
+`Orchestrator` follow in later PRs; the class disappears with #267, at which
+point every row in the table above is an extracted service.
 
-The split is visible at the route: each service has its own provider in `qfa.api.dependencies` (`get_orchestrator`, `get_sensitivity_service`, `get_coding_service`), and a handler annotates against the single service it calls — so which use cases a route can reach is readable from its signature.
+The split is visible at the route: each service has its own provider in `qfa.api.dependencies` (the Provider column above), and a handler annotates against the single service it calls — so which use cases a route can reach is readable from its signature.
 
 Each method is pure use-case logic — no scope or correlation plumbing. `call_scope` is entered by a FastAPI dependency declared on the route (`Depends(call_scope_for(Operation.X))`), so by the time a service method runs `current_call_context` is already set. See [Cross-cutting concerns](04-crosscutting.md) for the full picture.
-
-### Extracted use-case services
-
-Each service below is a plain class in `qfa.services` that owns exactly one use
-case, receives the shared {py:class}`~qfa.services.llm_call_executor.LLMCallExecutor`
-as a constructor dependency, and is injected into its route by its own provider in
-`qfa.api.dependencies`. None of them has a base class — see
-[ADR-017](../adr/017-orchestrator-composition-only.md).
-
-| Service | Endpoint | Provider | What it does |
-|---|---|---|---|
-| {py:class}`~qfa.services.sensitivity.SensitivityService` | `POST /v1/detect-sensitive` | `get_sensitivity_service` | One LLM call per record. Detects sensitive content and categorizes sensitivity types. |
-| {py:class}`~qfa.services.coding.CodingService` | `POST /v1/assign-codes` | `get_coding_service` | Multiple LLM calls per record: pick + judge at each level of a hierarchical coding framework. |
 
 ### The LLM-call executor
 

--- a/src/qfa/services/coding.py
+++ b/src/qfa/services/coding.py
@@ -14,8 +14,8 @@ framework rather than a fixed sequence of calls, which is why it lives in
 its own module (ADR-017): its private helpers are used by nothing else.
 
 Per ADR-017 :class:`CodingService` has **no base class**. The scaffolding
-it shares with the other use cases — the token-budget guard — comes from
-the injected
+it shares with the other use cases — the token-budget guard and the
+deadline→timeout derivation — comes from the injected
 :class:`~qfa.services.llm_call_executor.LLMCallExecutor`, and everything
 else it needs (the LLM connection, the anonymiser) is named explicitly in
 its constructor.

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -333,6 +333,14 @@ def test_app(fake_orchestrator, fake_auth_orchestrator):
     # The extracted use-case services get their own app.state slot (ADR-017).
     # FakeOrchestrator still implements every use case, so one fake backs all
     # of them until the remaining extractions land.
+    #
+    # These are three bindings to one object, not an alias: rebinding
+    # `state.orchestrator` in a test does NOT reach `/v1/detect-sensitive` or
+    # `/v1/assign-codes`, which keep reading the slots below. A test that needs
+    # a failing service on one of those routes must assign that route's own slot
+    # (see `test_detect_sensitive_502_analysis_error`) — the `TestErrorMapping`
+    # idiom of swapping `state.orchestrator` would pass vacuously against the
+    # healthy double here.
     app.state.sensitivity_service = fake_orchestrator
     app.state.coding_service = fake_orchestrator
     app.state.auth_orchestrator = fake_auth_orchestrator

--- a/tests/services/test_orchestrator_judge_routing.py
+++ b/tests/services/test_orchestrator_judge_routing.py
@@ -470,13 +470,14 @@ class TestGenerationCallsStayOnThePrimaryClient:
         analyse and summarise. Pinned here so the exclusion is a recorded
         decision rather than something a later reader assumes was an oversight.
 
-        Since #265 the exclusion is structural as well as behavioural:
+        Since #265 the exclusion is also structural — the constructor of
         :class:`~qfa.services.coding.CodingService` takes no judge client, so
-        a judge client that exists in the same process is unreachable from
-        this path. Both halves are asserted below.
+        there is no seam to inject one through. That half is enforced by the
+        signature and cannot be asserted here; what this test still pins is the
+        behavioural half: both the pick and the judge call are served by the
+        primary connection.
         """
         primary = RoutingLLM("primary")
-        judge = RoutingLLM("judge")
         coding = _build_coding_service(primary)
 
         await coding.assign_codes(
@@ -493,7 +494,6 @@ class TestGenerationCallsStayOnThePrimaryClient:
         )
 
         assert primary.response_models == [CodingResponse, JudgeResponse]
-        assert judge.calls == []
 
 
 class TestCostAccountingAcrossBothClients:


### PR DESCRIPTION
Follow-up to #279, which merged while the review findings were being addressed. Same findings, applied on top of `main`.

## What changed

**Lost-in-rebase content from #275 restored** — this is the substantive one. #279 was rebased onto `main` after #275 landed, and the rebase silently reverted #275's rewritten `assign_codes` description in `docs/architecture/03-components.md`, putting the superseded *"Multiple LLM calls per record: pick + judge at each level"* text back. Restored to #275's wording (*"One LLM call picks the best-fitting code path(s) directly from the whole flattened coding framework, then a separate judge call per level scores each selected path, root to leaf."*).

I checked the rest of #275 the same way: its changes to `llm_client.py`, `domain/errors.py`, `coding_classifier.py`, `rest-api/index.md` and `routes.py` are all intact on `main`, all 17 tests it added are present, and the code moved into `coding.py` is byte-identical to `main`'s post-#275 `orchestrator.py`. The one doc row was the only casualty.

**Also corrected while in that file:** `docs/architecture/01-architecture-style.md` claimed `detect_sensitive_content` still sits on `Orchestrator`. #277 extracted it; the method is gone from the class.

**Two service tables folded into one** (`03-components.md`) — `CodingService` and `SensitivityService` appeared both in "The application services" and in "Extracted use-case services", two rows to keep in step per extraction with more of epic #112 coming. The provider column moves into the first table and the second is dropped; when `Orchestrator` disappears with #267 the remaining table is already the right one. The `#the-application-services` anchor is unchanged, so the link from `implementing-a-new-endpoint.md` still resolves.

**`tests/api/conftest.py`** — the fixture binds one `FakeOrchestrator` to three `app.state` slots at setup time, so the `TestErrorMapping` idiom of rebinding `state.orchestrator` does *not* reach `/v1/detect-sensitive` or `/v1/assign-codes`. Nothing regresses today — no assign-codes error-mapping test exists — but one written to the house idiom would pass vacuously against the healthy double. The comment now says that plainly and points at the slot to set instead.

**`tests/services/test_orchestrator_judge_routing.py`** — in `test_coding_classification_stays_entirely_on_the_primary`, the `RoutingLLM("judge")` local was handed to nobody once `CodingService` stopped taking a judge client, so `assert judge.calls == []` held regardless of what the code did. Dropped the local and the assertion; the docstring now claims only the behavioural half the test still checks (`primary.response_models == [CodingResponse, JudgeResponse]`) and notes that the structural half is enforced by the constructor signature, not here.

**Coding module docstring** widened: post-#275 `CodingService` uses the executor for the deadline-derived timeout as well as the token-budget guard.

## Findings deliberately not acted on

Three review findings said so themselves and I agree:
- `composition.py` — `build_orchestrator` building the full `ServiceGraph` and discarding the `CodingService`: explicitly "no change requested".
- `tests/services/test_coding.py` importing doubles from `test_orchestrator`: worth moving to `tests/services/conftest.py` when a third module wants the same pair, and it would mean editing a test file no finding names.
- `coding.py` — the two `self._llm.complete(...)` calls without an explicit `timeout=`: pre-existing and byte-identical to `main`, out of scope for a pure extraction. Worth a follow-up in the epic that routes them through `executor.complete()`.

## Verification

`make lint` — ruff, `ty`, all three import-linter contracts kept. `make test` — 644 passed. `make docs` builds clean.

Not run: the 42 `integration`/`e2e` tests are deselected by default and need Postgres, unavailable in this container. No source behaviour changed here, only docs, comments and one dead assertion.

Follow-up to #279 · Fixes #265

~Written by Claude, run via the agentic engineering loop